### PR TITLE
New example: UpdateStaking

### DIFF
--- a/Examples/UpdateStaking/main.swift
+++ b/Examples/UpdateStaking/main.swift
@@ -1,0 +1,65 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ *
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import Foundation
+import Hedera
+import SwiftDotenv
+
+@main
+public enum Program {
+    public static func main() async throws {
+        let env = try Dotenv.load()
+        let client = Client.forTestnet()
+
+        client.setOperator(env.operatorAccountId, env.operatorKey)
+
+        let nodeId = UInt64(1)
+        let transactionResponse = try await AccountUpdateTransaction()
+            .accountId(env.operatorAccountId)
+            .stakedNodeId(nodeId)
+            .execute(client)
+        
+        // either of these values can be used to lookup transactions in an explorer such as
+        //  Kabuto or DragonGlass; the transaction ID is generally more useful as it also contains a rough
+        //  estimation of when the transaction was created (+/- 8 seconds) and the account that paid for
+        //  transaction
+        print("transaction id: \(transactionResponse.transactionId)")
+        print("transaction hash: \(transactionResponse.transactionHash)")
+        
+        let receipt = try await transactionResponse.getReceipt(client)
+        print("receipt=\( receipt.status )")
+        
+        if receipt.status == .ok {
+            
+            print("\( env.operatorAccountId ) is now staking to node \( nodeId )")
+
+        }
+    }
+}
+
+extension Environment {
+    internal var operatorAccountId: AccountId {
+        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+    }
+
+    internal var operatorKey: PrivateKey {
+        PrivateKey(self["OPERATOR_KEY"]!.stringValue)!
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,7 @@ let exampleTargets = [
     "TransferHbar",
     "GetAddressBook",
     "GetFileContents",
+    "UpdateStaking",
 ].map { name in
     Target.executableTarget(
         name: "\(name)Example",


### PR DESCRIPTION
**Description**:

The changes below adds a new example: UpdateStaking.
This example demonstrates how to change staked_node_id field of an account.
It is constructed with the same pattern as other examples.

Note: this example currently reports an error because of issue #33.
