### PR TITLE
refactor: Make TopicMessage match other SDKs

### DIFF
--- a/Sources/Hedera/Timestamp.swift
+++ b/Sources/Hedera/Timestamp.swift
@@ -8,7 +8,11 @@ private let timeZoneUTC: TimeZone = TimeZone(abbreviation: "UTC")!
 private let unixEpoch: Date = Calendar.current.date(from: DateComponents(timeZone: timeZoneUTC, year: 1970))!
 
 /// UNIX timestamp with nanosecond precision
-public struct Timestamp: Sendable, Equatable, CustomStringConvertible {
+public struct Timestamp: Sendable, Equatable, Hashable, CustomStringConvertible, Comparable {
+    public static func < (lhs: Timestamp, rhs: Timestamp) -> Bool {
+        lhs.seconds < rhs.seconds || (lhs.seconds == rhs.seconds && lhs.subSecondNanos < rhs.subSecondNanos)
+    }
+
     public let seconds: UInt64
     public let subSecondNanos: UInt32
 
@@ -20,6 +24,10 @@ public struct Timestamp: Sendable, Equatable, CustomStringConvertible {
     public init(fromUnixTimestampNanos nanos: UInt64) {
         self.seconds = nanos / nanosPerSecond
         self.subSecondNanos = UInt32(nanos % nanosPerSecond)
+    }
+
+    internal func adding(nanos: UInt64) -> Self {
+        Self(fromUnixTimestampNanos: unixTimestampNanos + nanos)
     }
 
     internal func subtracting(nanos: UInt64) -> Self {

--- a/Sources/Hedera/TransactionId.swift
+++ b/Sources/Hedera/TransactionId.swift
@@ -1,7 +1,7 @@
 import Foundation
 import HederaProtobufs
 
-public struct TransactionId: Sendable, Equatable, ExpressibleByStringLiteral, LosslessStringConvertible,
+public struct TransactionId: Sendable, Equatable, Hashable, ExpressibleByStringLiteral, LosslessStringConvertible,
     ValidateChecksums
 {
     /// The Account ID that paid for this transaction.

--- a/Sources/Hedera/TransactionResponse.swift
+++ b/Sources/Hedera/TransactionResponse.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-/// Response from ``Transaction/execute(_:_:)``.
+/// Response from ``Transaction/execute(_:_:).
 ///
 /// When the client sends a node a transaction of any kind, the node replies with this, which
 /// simply says that the transaction passed the pre-check (so the node will submit it to

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,10 +1,5 @@
 version: "3"
 
-includes:
-    ":rust":
-        taskfile: ../rust/Taskfile.yml
-        dir: ../rust
-
 tasks:
     build:
         cmds:


### PR DESCRIPTION
**Description**:

This is the Swift equivalent of hashgraph/hedera-sdk-rust#498

**Related issue(s)**:

- Fixes #71 
- Fixes #72 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
