### PR TITLE
fix: ensure transaction.toBytes signs the sources if they exist

### DIFF
--- a/Sources/Hedera/Transaction.swift
+++ b/Sources/Hedera/Transaction.swift
@@ -388,7 +388,7 @@ public class Transaction: ValidateChecksums {
     public final func toBytes() throws -> Data {
         precondition(isFrozen, "Transaction must be frozen to call `toBytes`")
 
-        if let sources = self.sources {
+        if let sources = self.sources?.signWithSigners(self.signers) {
             return sources.toBytes()
         }
 
@@ -433,7 +433,7 @@ extension Transaction {
         }
         return HError(
             kind: .transactionPreCheckStatus(status: status, transactionId: transactionId),
-            description: "transaction `\(transactionId)` failed pre-check with status `\(status)"
+            description: "transaction `\(transactionId)` failed pre-check with status `\(status)`"
         )
     }
 


### PR DESCRIPTION
**Description**:
Found this bug in the rust SDK, and checked here to ensure it either wasn't here or got fixed as well... It was here
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
