### PR TITLE
receipt exchange rate

### DIFF
--- a/Sources/Hedera/Account/AccountBalance.swift
+++ b/Sources/Hedera/Account/AccountBalance.swift
@@ -50,7 +50,7 @@ extension TokenBalance: ProtobufCodable {
 }
 
 /// Response from ``AccountBalanceQuery``.
-public struct AccountBalance {
+public struct AccountBalance: Sendable {
     /// The account that is being referenced.
     public let accountId: AccountId
 

--- a/Sources/Hedera/Account/AccountInfo.swift
+++ b/Sources/Hedera/Account/AccountInfo.swift
@@ -22,7 +22,7 @@ import Foundation
 import HederaProtobufs
 
 /// Response from `AccountInfoQuery`.
-public struct AccountInfo {
+public struct AccountInfo: Sendable {
     private struct DeprecatedGuts {
         fileprivate let proxyAccountId: AccountId?
         fileprivate let sendRecordThreshold: Hbar

--- a/Sources/Hedera/AssessedCustomFee.swift
+++ b/Sources/Hedera/AssessedCustomFee.swift
@@ -2,7 +2,7 @@ import Foundation
 import HederaProtobufs
 
 /// A custom transfer fee that was assessed during the handling of a ``TransferTransaction``.
-public struct AssessedCustomFee: Equatable {
+public struct AssessedCustomFee: Sendable, Equatable {
     /// The amount of currency charged to each payer.
     public let amount: Int64
 

--- a/Sources/Hedera/Contract/ContractFunctionResult.swift
+++ b/Sources/Hedera/Contract/ContractFunctionResult.swift
@@ -261,3 +261,10 @@ extension ContractFunctionResult: TryFromProtobuf {
         )
     }
 }
+
+#if compiler(<5.7)
+    // Swift 5.7 added the conformance to data, despite to the best of my knowledge, not changing anything in the underlying type.
+    extension ContractFunctionResult: @unchecked Sendable {}
+#else
+    extension ContractFunctionResult: Sendable {}
+#endif

--- a/Sources/Hedera/Contract/ContractLogInfo.swift
+++ b/Sources/Hedera/Contract/ContractLogInfo.swift
@@ -46,3 +46,10 @@ extension ContractLogInfo: TryProtobufCodable {
         }
     }
 }
+
+#if compiler(<5.7)
+    // Swift 5.7 added the conformance to data, despite to the best of my knowledge, not changing anything in the underlying type.
+    extension ContractLogInfo: @unchecked Sendable {}
+#else
+    extension ContractLogInfo: Sendable {}
+#endif

--- a/Sources/Hedera/Contract/ContractNonceInfo.swift
+++ b/Sources/Hedera/Contract/ContractNonceInfo.swift
@@ -23,7 +23,7 @@ import struct HederaProtobufs.Proto_ContractNonceInfo
 
 // Info about a contract account's nonce value.
 /// The nonce for a contract is only incremented when that contract creates another contract.
-public struct ContractNonceInfo: Equatable {
+public struct ContractNonceInfo: Sendable, Equatable {
     /// The contract's ID.
     public let contractId: ContractId
     /// The contract's nonce.

--- a/Sources/Hedera/Contract/DelegateContractId.swift
+++ b/Sources/Hedera/Contract/DelegateContractId.swift
@@ -23,7 +23,7 @@ import HederaProtobufs
 
 // fixme(sr,docs): describe what a Delegate contract ID is actually for / what it does / etc.
 /// A unique identifier for a smart contract on Hedera.
-public struct DelegateContractId: EntityId {
+public struct DelegateContractId: Sendable, EntityId {
     private init(_ inner: ContractId) {
         self.inner = inner
     }

--- a/Sources/Hedera/ExchangeRates.swift
+++ b/Sources/Hedera/ExchangeRates.swift
@@ -22,7 +22,7 @@ import Foundation
 import HederaProtobufs
 
 /// The current and next exchange rates between ``Hbar`` and USD-cents.
-public struct ExchangeRates {
+public struct ExchangeRates: Sendable {
     /// The current exchange rate between Hbar and USD-cents.
     public let currentRate: ExchangeRate
     /// The next exchange rate between Hbar and USD-cents.
@@ -38,7 +38,7 @@ public struct ExchangeRates {
     }
 }
 
-extension ExchangeRates: FromProtobuf {
+extension ExchangeRates: ProtobufCodable {
     internal typealias Protobuf = Proto_ExchangeRateSet
 
     internal init(protobuf proto: Protobuf) {
@@ -47,10 +47,17 @@ extension ExchangeRates: FromProtobuf {
             nextRate: .fromProtobuf(proto.nextRate)
         )
     }
+
+    internal func toProtobuf() -> Protobuf {
+        .with { proto in
+            proto.currentRate = currentRate.toProtobuf()
+            proto.nextRate = nextRate.toProtobuf()
+        }
+    }
 }
 
 /// Denotes a conversion between Hbars and cents (USD).
-public struct ExchangeRate {
+public struct ExchangeRate: Sendable {
     /// Denotes Hbar equivalent to cents (USD).
     public let hbars: UInt32
 
@@ -66,7 +73,7 @@ public struct ExchangeRate {
     }
 }
 
-extension ExchangeRate: FromProtobuf {
+extension ExchangeRate: ProtobufCodable {
     internal typealias Protobuf = Proto_ExchangeRate
 
     internal init(protobuf proto: Protobuf) {
@@ -75,5 +82,13 @@ extension ExchangeRate: FromProtobuf {
             cents: UInt32(proto.centEquiv),
             expirationTime: .init(seconds: UInt64(proto.expirationTime.seconds), subSecondNanos: 0)
         )
+    }
+
+    internal func toProtobuf() -> Protobuf {
+        .with { proto in
+            proto.hbarEquiv = Int32(bitPattern: hbars)
+            proto.centEquiv = Int32(bitPattern: cents)
+            proto.expirationTime = Proto_TimestampSeconds.with { $0.seconds = Int64(expirationTime.seconds) }
+        }
     }
 }

--- a/Sources/Hedera/File/FileContentsQuery.swift
+++ b/Sources/Hedera/File/FileContentsQuery.swift
@@ -56,7 +56,7 @@ public final class FileContentsQuery: Query<FileContentsResponse> {
             throw HError.fromProtobuf("unexpected \(response) received, expected `fileGetContents`")
         }
 
-        return try .fromProtobuf(proto.fileContents)
+        return .fromProtobuf(proto.fileContents)
     }
 
     internal override func validateChecksums(on ledgerId: LedgerId) throws {

--- a/Sources/Hedera/File/FileContentsResponse.swift
+++ b/Sources/Hedera/File/FileContentsResponse.swift
@@ -44,3 +44,10 @@ extension FileContentsResponse: ProtobufCodable {
         }
     }
 }
+
+#if compiler(<5.7)
+    // Swift 5.7 added the conformance to data, despite to the best of my knowledge, not changing anything in the underlying type.
+    extension FileContentsResponse: @unchecked Sendable {}
+#else
+    extension FileContentsResponse: Sendable {}
+#endif

--- a/Sources/Hedera/Key.swift
+++ b/Sources/Hedera/Key.swift
@@ -22,7 +22,7 @@ import Foundation
 import HederaProtobufs
 
 /// Any method that can be used to authorize an operation on Hedera.
-public enum Key: Equatable {
+public enum Key: Sendable, Equatable {
     case single(PublicKey)
     case contractId(ContractId)
 

--- a/Sources/Hedera/KeyList.swift
+++ b/Sources/Hedera/KeyList.swift
@@ -1,6 +1,6 @@
 import HederaProtobufs
 
-public struct KeyList: ExpressibleByArrayLiteral, Equatable {
+public struct KeyList: Sendable, ExpressibleByArrayLiteral, Equatable {
     public typealias ArrayLiteralElement = Key
 
     public var keys: [Key]

--- a/Sources/Hedera/Schedule/ScheduleInfo.swift
+++ b/Sources/Hedera/Schedule/ScheduleInfo.swift
@@ -22,7 +22,7 @@ import Foundation
 import HederaProtobufs
 
 /// Response from `ScheduleInfoQuery`.
-public struct ScheduleInfo {
+public struct ScheduleInfo: Sendable {
     /// The ID of the schedule for which information is requested.
     public let scheduleId: ScheduleId
 

--- a/Sources/Hedera/StakingInfo.swift
+++ b/Sources/Hedera/StakingInfo.swift
@@ -22,7 +22,7 @@ import Foundation
 import HederaProtobufs
 
 /// Info related to account/contract staking settings.
-public struct StakingInfo {
+public struct StakingInfo: Sendable {
     /// If true, the contract declines receiving a staking reward. The default value is false.
     public let declineStakingReward: Bool
 

--- a/Sources/Hedera/Token/TokenAssociation.swift
+++ b/Sources/Hedera/Token/TokenAssociation.swift
@@ -22,7 +22,7 @@ import Foundation
 import HederaProtobufs
 
 /// A token <-> account association.
-public struct TokenAssociation {
+public struct TokenAssociation: Sendable {
     /// The token involved in the association.
     public let tokenId: TokenId
 

--- a/Sources/Hedera/Token/TokenNftTransfer.swift
+++ b/Sources/Hedera/Token/TokenNftTransfer.swift
@@ -2,7 +2,7 @@
 
 import HederaProtobufs
 
-public struct TokenNftTransfer: Equatable {
+public struct TokenNftTransfer: Sendable, Equatable {
     /// The ID of the NFT's token.
     public let tokenId: TokenId
 

--- a/Sources/Hedera/TopicMessage.swift
+++ b/Sources/Hedera/TopicMessage.swift
@@ -2,7 +2,7 @@ import Foundation
 import HederaProtobufs
 
 /// Metadata for an individual chunk of a `TopicMessage`.
-public struct TopicMessageChunk {
+public struct TopicMessageChunk: Sendable {
     /// The consensus timestamp for this chunk.
     public let consensusTimestamp: Timestamp
 
@@ -28,7 +28,7 @@ extension TopicMessageChunk {
 }
 
 /// Topic message records.
-public struct TopicMessage {
+public struct TopicMessage: Sendable {
     /// The consensus timestamp of the message.
     ///
     /// If there are multiple chunks, this is taken from the *last* chunk.

--- a/Sources/Hedera/TransactionReceipt.swift
+++ b/Sources/Hedera/TransactionReceipt.swift
@@ -107,9 +107,9 @@ public struct TransactionReceipt: Sendable {
     public let scheduleId: ScheduleId?
 
     /// The current exchange rate between Hbar and USD-cents.
-    /// 
+    ///
     /// This exists purely for "Well, I expected this name to exist because it exists in JS"
-    /// 
+    ///
     /// This is just a getter property for `current` in ``TransactionReceipt/exchangeRates``
     public var exchangeRate: ExchangeRate? {
         exchangeRates?.currentRate

--- a/Sources/Hedera/TransactionReceipt.swift
+++ b/Sources/Hedera/TransactionReceipt.swift
@@ -21,7 +21,6 @@
 import Foundation
 import HederaProtobufs
 
-// TODO: exchangeRate
 /// The summary of a transaction's result so far, if the transaction has reached consensus.
 public struct TransactionReceipt: Sendable {
     internal init(
@@ -37,6 +36,7 @@ public struct TransactionReceipt: Sendable {
         tokenId: TokenId? = nil,
         totalSupply: UInt64,
         scheduleId: ScheduleId? = nil,
+        exchangeRates: ExchangeRates? = nil,
         scheduledTransactionId: TransactionId? = nil,
         serials: [UInt64]? = nil,
         duplicates: [TransactionReceipt],
@@ -54,6 +54,7 @@ public struct TransactionReceipt: Sendable {
         self.tokenId = tokenId
         self.totalSupply = totalSupply
         self.scheduleId = scheduleId
+        self.exchangeRates = exchangeRates
         self.scheduledTransactionId = scheduledTransactionId
         self.serials = serials
         self.duplicates = duplicates
@@ -104,6 +105,18 @@ public struct TransactionReceipt: Sendable {
 
     /// In the receipt for a `ScheduleCreateTransaction`, the id of the newly created schedule.
     public let scheduleId: ScheduleId?
+
+    /// The current exchange rate between Hbar and USD-cents.
+    /// 
+    /// This exists purely for "Well, I expected this name to exist because it exists in JS"
+    /// 
+    /// This is just a getter property for `current` in ``TransactionReceipt/exchangeRates``
+    public var exchangeRate: ExchangeRate? {
+        exchangeRates?.currentRate
+    }
+
+    /// The current and next exchange rate between Hbar and USD-cents.
+    public let exchangeRates: ExchangeRates?
 
     /// In the receipt of a `ScheduleCreateTransaction` or `ScheduleSignTransaction` that resolves
     /// to `Success`, the `TransactionId` that should be used to query for the receipt or
@@ -204,6 +217,7 @@ extension TransactionReceipt: TryProtobufCodable {
             tokenId?.toProtobufInto(&proto.tokenID)
             proto.newTotalSupply = totalSupply
             scheduleId?.toProtobufInto(&proto.scheduleID)
+            exchangeRates?.toProtobufInto(&proto.exchangeRate)
             scheduledTransactionId?.toProtobufInto(&proto.scheduledTransactionID)
             proto.serialNumbers = serials?.map(Int64.init) ?? []
         }

--- a/Sources/Hedera/TransactionRecord.swift
+++ b/Sources/Hedera/TransactionRecord.swift
@@ -190,3 +190,10 @@ extension TransactionRecord: TryFromProtobuf {
         try self.init(protobuf: proto, duplicates: [], children: [])
     }
 }
+
+#if compiler(<5.7)
+    // Swift 5.7 added the conformance to data, despite to the best of my knowledge, not changing anything in the underlying type.
+    extension TransactionRecord: @unchecked Sendable {}
+#else
+    extension TransactionRecord: Sendable {}
+#endif

--- a/Sources/Hedera/TransactionResponse.swift
+++ b/Sources/Hedera/TransactionResponse.swift
@@ -28,7 +28,7 @@ import Foundation
 ///
 /// To learn the consensus result, the client should later obtain a
 /// receipt (free), or can buy a more detailed record (not free).
-public struct TransactionResponse {
+public struct TransactionResponse: Sendable {
     /// The account ID of the node that the transaction was submitted to.
     public let nodeAccountId: AccountId
 

--- a/Sources/Hedera/Transfer.swift
+++ b/Sources/Hedera/Transfer.swift
@@ -4,7 +4,7 @@ import HederaProtobufs
 /// A transfer of ``Hbar`` that occured within a ``Transaction``
 ///
 /// Returned as part of a ``TransactionRecord``
-public struct Transfer {
+public struct Transfer: Sendable {
     /// The account ID that this transfer is to/from.
     public let accountId: AccountId
 


### PR DESCRIPTION
**Description**:
- Add various `Sendable` conformances (They should exist, just, easy to miss them)
- Add `exchangeRates` to `TransactionReceipt`.
  -  Note that unlike JS, Java, and Go, (but like CPP), this is the current *and next*. However, an equivalent `exchangeRate` property exists anyway, so, in practice this isn't really a divergence.

**Related issue(s)**:

- Fixes #259 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
