### PR TITLE
Clean up various todos

### DIFF
--- a/Examples/ScheduleMultiSigTransaction/main.swift
+++ b/Examples/ScheduleMultiSigTransaction/main.swift
@@ -65,13 +65,6 @@ internal enum Program {
 
         print("accountId = \(accountId)")
 
-        // fixme: This is actually unused in this SDK, Java, and Rust, figure out if this is supposed to actually exist or not.
-        // Generate a `TransactionId`. This id is used to query the inner scheduled transaction
-        // after we expect it to have been executed
-        let transactionId = TransactionId.generateFrom(env.operatorAccountId)
-
-        print("transactionId for scheduled transaction = \(transactionId)")
-
         // Create a transfer transaction with 2/3 signatures.
         let transferTransaction = TransferTransaction()
             .hbarTransfer(accountId, -Hbar(1))

--- a/Sources/Hedera/Checksum.swift
+++ b/Sources/Hedera/Checksum.swift
@@ -33,7 +33,7 @@ public struct Checksum: Sendable, LosslessStringConvertible, Hashable {
 
     internal init<S: StringProtocol>(parsing description: S) throws {
         guard let tmp = Self(description) else {
-            throw HError(kind: .basicParse, description: "Invalid checksum string \(description)")
+            throw HError.basicParse("Invalid checksum string \(description)")
         }
 
         self = tmp
@@ -63,73 +63,79 @@ public struct Checksum: Sendable, LosslessStringConvertible, Hashable {
         data
     }
 
-    internal static func generate<E: EntityId>(for entity: E, on ledgerId: LedgerId) -> Self {
-        // todo: fix these
-        // swiftlint:disable identifier_name
-        // 3 digits in base 26
-        let p3 = 26 * 26 * 26
-        // 5 digits in base 26
-        let p5 = 26 * 26 * 26 * 26 * 26
+    /// The base used for the checksum (ascii a-z is base 26)
+    private static let base = 26
+    /// 3 digits in `base`
+    private static let digits3 = base.toPower(of: 3)
+    /// 5 digits in `base`
+    private static let digits5 = base.toPower(of: 5)
+    //. Sum s of digit values weights them by powers of W. Should be coprime to ``digits5``.
+    private static let weight = 31
+    /// ``weight`` to the 6th power.
+    private static let weight6 = weight.toPower(of: 6)
 
-        // min prime greater than a million. Used for the final permutation.
-        let m = 1_000_003
-
-        // Sum s of digit values weights them by powers of W. Should be coprime to P5.
-        let w = 31
-        // W to the 6th power
-        let w6 = w * w * w * w * w * w
-
-        // don't need the six 0 bytes.
-        let h = ledgerId.bytes
-
-        let d = entity.description.map { $0 == "." ? 10 : $0.wholeNumberValue! }
-
-        // Weighted sum of all positions (mod P3)
-        var s = 0
-        // Sum of even positions (mod 11)
-        var s0 = 0
-        // Sum of odd positions (mod 11)
-        var s1 = 0
-
-        for (index, digit) in d.enumerated() {
-            s = (w * s + digit) % p3
-            if index.isOdd {
-                s1 += digit
-            } else {
-                s0 += digit
-            }
-        }
-
-        s0 = s0 % 11
-        s1 = s1 % 11
+    /// Computes the hash of a given ledger ID (sh).
+    ///
+    /// >Note: This is always the same for a given ledger ID.
+    private static func ledgerIdHash(ledgerId: LedgerId) -> Int {
+        // we can specialize for known ledger IDs since they're, well, known, but it isn't actually clear if that'd be better codegen, thanks swift.
 
         // instead of six 0 bytes, we compute this in two steps
-        var sh = h.reduce(0) { (result, value) in (w * result + Int(value)) % p5 }
+        var sh = ledgerId.bytes.reduce(0) { (result, value) in (weight * result + Int(value)) % digits5 }
         // `(w * result + Int(0)) % p5` applied 6 times...
         // `(w * result + Int(0)) % p5 = (w * result) % p5` because 0 is the additive identity
         // then expanding out the full expression:
         // `((w * ((w * ((w * ((w * ((w * ((w * result) % p5)) % p5)) % p5)) % p5)) % p5)) % p5)`
         // ... and using the fact that `((x % y) * z) % y = (x * z) % y`
         // we get:
-        sh = (sh * w6) % p5
+        sh = (sh * weight6) % digits5
+
+        return sh
+    }
+
+    internal static func generate<E: EntityId>(for entity: E, on ledgerId: LedgerId) -> Self {
+        // min prime greater than a million. Used for the final permutation.
+        let minPrime = 1_000_003
+
+        let digits = entity.description.map { $0 == "." ? 10 : $0.wholeNumberValue! }
+
+        // Weighted sum of all positions (mod P3)
+        var sum = 0
+        // Sum of even positions (mod 11)
+        var evenSum = 0
+        // Sum of odd positions (mod 11)
+        var oddSum = 0
+
+        for (index, digit) in digits.enumerated() {
+            sum = (weight * sum + digit) % digits3
+            if index.isOdd {
+                oddSum += digit
+            } else {
+                evenSum += digit
+            }
+        }
+
+        evenSum = evenSum % 11
+        oddSum = oddSum % 11
 
         // original expression:
         // var c = ((((((entityIdString.count % 5) * 11 + s0) * 11 + s1) * p3 + s + sh) % p5) * m) % p5
         // but `((x % y) * z) % y = ((x * z) % y) % y = (x * z) % y`
         // checksum as a single number
-        var c = (((((d.count % 5) * 11 + s0) * 11 + s1) * p3 + s + sh) * m) % p5
+        // computation is split into two parts because it's a big expression.
+        var c = ((digits.count % 5) * 11 + evenSum) * 11 + oddSum
+        c = ((c * digits3 + sum + ledgerIdHash(ledgerId: ledgerId)) * minPrime) % digits5
 
         var output: [UInt8] = [0, 0, 0, 0, 0]
 
         for i in (0..<5).reversed() {
             let asciiLowercaseA = 0x61
-            output[i] = UInt8(asciiLowercaseA + c % 26)
-            c /= 26
+            let res = c.quotientAndRemainder(dividingBy: base)
+            output[i] = UInt8(asciiLowercaseA + res.remainder)
+            c = res.quotient
         }
 
         // thanks swift, for not having fixed length arrays
         return Checksum(bytes: (output[0], output[1], output[2], output[3], output[4]))
-
-        // swiftlint:enable identifier_name
     }
 }

--- a/Sources/Hedera/Client/Client.swift
+++ b/Sources/Hedera/Client/Client.swift
@@ -201,7 +201,7 @@ public final class Client: Sendable {
             return .forPreviewnet()
 
         default:
-            throw HError(kind: .basicParse, description: "Unknown network name \(name)")
+            throw HError.basicParse("Unknown network name \(name)")
         }
     }
 

--- a/Sources/Hedera/Client/Network.swift
+++ b/Sources/Hedera/Client/Network.swift
@@ -31,8 +31,7 @@ internal final class ChannelBalancer: GRPCChannel {
     private let channels: [any GRPCChannel]
     private let targets: [GRPC.ConnectionTarget]
 
-    // fixme: if the request never returns (IE the host doesn't exist) we
-
+    // fixme: if the request never returns (IE the host doesn't exist) we kinda just, get stuck
     internal init(
         eventLoop: EventLoop,
         _ channelTargets: [GRPC.ConnectionTarget],

--- a/Sources/Hedera/Crypto/Pkcs5.swift
+++ b/Sources/Hedera/Crypto/Pkcs5.swift
@@ -36,14 +36,29 @@ extension ASN1ObjectIdentifier.NamedCurves {
     ///
     /// `iso(1) identified-organization(3) certicom(132) curve(0) 10`
     internal static let secp256k1: ASN1ObjectIdentifier = [1, 3, 132, 0, 10]
-    // fixme: is this supposed to be *here*? It doesn't reaaally matter but...
-    /// OID
-    internal static let ed25519: ASN1ObjectIdentifier = [1, 3, 101, 112]
 }
 
 extension ASN1ObjectIdentifier.AlgorithmIdentifier {
+    /// OID for the ed25519 algorithm.
+    ///
+    /// `iso(1) identified-organization(3) thawte(101) id-Ed25519(112)`
+    ///
+    /// `101.100` through `101.127` were donated to the IETF Curdle Security Working Group for the sake of Edwards Elliptic Curves with smaller arcs, hence the weird spot.
+    internal static let ed25519: ASN1ObjectIdentifier = [1, 3, 101, 112]
+
+    /// OID for the password based key derivation function version 2 (PBKDF2) algorithm.
+    ///
+    /// `iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-5(5) id-PBKDF2(12)`
     internal static let pbkdf2: ASN1ObjectIdentifier = [1, 2, 840, 113_549, 1, 5, 12]
+
+    /// OID for the password based key derivation function version 2 (PBKDF2) algorithm.
+    ///
+    /// `iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-5(5) id-PBES2(13)`
     internal static let pbes2: ASN1ObjectIdentifier = [1, 2, 840, 113_549, 1, 5, 13]
+
+    /// OID for AES 128 bit encryption in CBC mode with RFC-5652 padding.
+    ///
+    /// `joint-iso-itu-t(2).country(16).us(840).organization(1).gov(101).csor(3).nistAlgorithms(4).aes(1).aes128-CBC-PAD(2)`
     internal static let aes128CbcPad: ASN1ObjectIdentifier = [2, 16, 840, 1, 101, 3, 4, 1, 2]
 }
 

--- a/Sources/Hedera/Crypto/Pkcs5Pbkdf2.swift
+++ b/Sources/Hedera/Crypto/Pkcs5Pbkdf2.swift
@@ -86,7 +86,13 @@ extension Pkcs5 {
     ///   algid-hmacWithSHA1 }
     /// ```
     internal struct Pbkdf2Parameters {
-        // todo: note that hmacWithSha1 is bad even though it's the default
+        /// Make PBKDF2 Parameters.
+        ///
+        /// - Parameters:
+        ///   - salt: The salt for the derivation.
+        ///   - keyLength: the length of the resulting key, must be at least 1.
+        ///   - iterationCount: the number of iterations to use, must be between 1 and 10,000,000.
+        ///   - prf: a PRF to use, the default is `hmacWithSha1` for specification reasons, but you should absolutely use something else.
         internal init?(
             salt: Data,
             iterationCount: UInt32,

--- a/Sources/Hedera/Ethereum/EvmAddress.swift
+++ b/Sources/Hedera/Ethereum/EvmAddress.swift
@@ -27,7 +27,7 @@ public struct EvmAddress:
 
     internal init(_ data: Data) throws {
         guard data.count == 20 else {
-            throw HError(kind: .basicParse, description: "expected evm address to have 20 bytes, it had \(data.count)")
+            throw HError.basicParse("expected evm address to have 20 bytes, it had \(data.count)")
         }
 
         self.data = data
@@ -35,12 +35,11 @@ public struct EvmAddress:
 
     internal init<S: StringProtocol>(parsing description: S) throws {
         guard let description = description.stripPrefix("0x") else {
-            throw HError(kind: .basicParse, description: "expected evm address to have `0x` prefix")
+            throw HError.basicParse("expected evm address to have `0x` prefix")
         }
 
         guard let bytes = Data(hexEncoded: description) else {
-            // todo: better error message
-            throw HError(kind: .basicParse, description: "invalid evm address")
+            throw HError.basicParse("invalid evm address")
         }
 
         try self.init(bytes)

--- a/Sources/Hedera/FeeSchedule/RequestType.swift
+++ b/Sources/Hedera/FeeSchedule/RequestType.swift
@@ -25,10 +25,6 @@ import HederaProtobufs
 
 /// The functionality provided by Hedera.
 public enum RequestType {
-    // fixme: maybe we want to make this `nil` instead?
-    /// UNSPECIFIED - Need to keep first value as unspecified because first element is ignored and not parsed (0 is ignored by parser)
-    case none
-
     /// Transfer from one account to another.
     case cryptoTransfer
 
@@ -244,16 +240,12 @@ public enum RequestType {
 
     /// Execute a PRNG transaction.
     case utilPrng
-}
-
-extension RequestType: TryProtobufCodable {
-    internal typealias Protobuf = Proto_HederaFunctionality
 
     // this literally can't be smaller.
     // swiftlint:disable:next function_body_length
-    internal init(protobuf proto: Protobuf) throws {
+    internal init?(protobuf proto: Proto_HederaFunctionality) throws {
         switch proto {
-        case .none: self = .none
+        case .none: return nil
         case .cryptoTransfer: self = .cryptoTransfer
         case .cryptoUpdate: self = .cryptoUpdate
         case .cryptoDelete: self = .cryptoDelete
@@ -331,11 +323,8 @@ extension RequestType: TryProtobufCodable {
         }
     }
 
-    // this literally can't be smaller.
-    // swiftlint:disable:next function_body_length
-    internal func toProtobuf() -> Protobuf {
+    internal func toProtobuf() -> Proto_HederaFunctionality {
         switch self {
-        case .none: return .none
         case .cryptoTransfer: return .cryptoTransfer
         case .cryptoUpdate: return .cryptoUpdate
         case .cryptoDelete: return .cryptoDelete

--- a/Sources/Hedera/FeeSchedule/TransactionFeeSchedule.swift
+++ b/Sources/Hedera/FeeSchedule/TransactionFeeSchedule.swift
@@ -29,14 +29,14 @@ import HederaProtobufs
 public struct TransactionFeeSchedule {
     // missing_docs on memberwise init -> fine.
     // swiftlint:disable:next missing_docs
-    public init(requestType: RequestType, feeData: FeeData? = nil, fees: [FeeData]) {
+    public init(requestType: RequestType?, feeData: FeeData? = nil, fees: [FeeData]) {
         self.requestType = requestType
         self.feeData = feeData
         self.fees = fees
     }
 
     /// The request type that this fee schedule applies to.
-    public var requestType: RequestType
+    public var requestType: RequestType?
 
     /// Resource price coefficients.
     public var feeData: FeeData?
@@ -66,7 +66,7 @@ extension TransactionFeeSchedule: TryProtobufCodable {
 
     internal init(protobuf proto: Protobuf) throws {
         self.init(
-            requestType: try .fromProtobuf(proto.hederaFunctionality),
+            requestType: try .init(protobuf: proto.hederaFunctionality),
             feeData: proto.hasFeeData ? try .fromProtobuf(proto.feeData) : nil,
             fees: try .fromProtobuf(proto.fees)
         )
@@ -74,7 +74,7 @@ extension TransactionFeeSchedule: TryProtobufCodable {
 
     internal func toProtobuf() -> Protobuf {
         .with { proto in
-            proto.hederaFunctionality = requestType.toProtobuf()
+            proto.hederaFunctionality = requestType?.toProtobuf() ?? .none
             if let feeData = feeData?.toProtobuf() {
                 proto.feeData = feeData
             }

--- a/Sources/Hedera/File/FileInfo.swift
+++ b/Sources/Hedera/File/FileInfo.swift
@@ -21,8 +21,6 @@
 import Foundation
 import HederaProtobufs
 
-// TODO: keys
-
 /// Response from `FileInfoQuery`.
 public final class FileInfo {
     internal init(

--- a/Sources/Hedera/Hbar.swift
+++ b/Sources/Hedera/Hbar.swift
@@ -189,7 +189,7 @@ public struct Hbar: LosslessStringConvertible, ExpressibleByIntegerLiteral,
         let unit = try rawUnit.map { try HbarUnit(parsing: $0) } ?? .hbar
 
         guard let amount = Decimal(string: String(rawAmount)) else {
-            throw HError(kind: .basicParse, description: "amount not parsable as a decimal")
+            throw HError.basicParse("amount not parsable as a decimal")
         }
 
         try self.init(amount, unit)

--- a/Sources/Hedera/NodeAddress.swift
+++ b/Sources/Hedera/NodeAddress.swift
@@ -30,7 +30,7 @@ public struct SocketAddressV4: LosslessStringConvertible {
 
     fileprivate init(ipBytes: Data, port: Int32) throws {
         guard let ipAddress = IPv4Address(ipBytes) else {
-            throw HError(kind: .basicParse, description: "expected 4 byte ip address, got `\(ipBytes.count)` bytes")
+            throw HError.basicParse("expected 4 byte ip address, got `\(ipBytes.count)` bytes")
         }
 
         guard let port = UInt16(exactly: port) else {
@@ -45,15 +45,15 @@ public struct SocketAddressV4: LosslessStringConvertible {
 
     fileprivate init<S: StringProtocol>(parsing description: S) throws {
         guard let (ipAddress, port) = description.splitOnce(on: ":") else {
-            throw HError(kind: .basicParse, description: "expected ip:port")
+            throw HError.basicParse("expected ip:port")
         }
 
         guard let ipAddress = IPv4Address(String(ipAddress)) else {
-            throw HError(kind: .basicParse, description: "expected `ip` to be a valid IP")
+            throw HError.basicParse("expected `ip` to be a valid IP")
         }
 
         guard let port = UInt16(port) else {
-            throw HError(kind: .basicParse, description: "expected 16 bit port number")
+            throw HError.basicParse("expected 16 bit port number")
         }
 
         self.ip = ipAddress

--- a/Sources/Hedera/PaymentTransaction.swift
+++ b/Sources/Hedera/PaymentTransaction.swift
@@ -26,8 +26,6 @@ internal final class PaymentTransaction: Transaction {
     internal var amount: Hbar?
     internal var maxAmount: Hbar?
 
-    // TODO: private var paymentSigners: [OpaquePointer] = [];
-
     internal override func toTransactionDataProtobuf(_ chunkInfo: ChunkInfo) -> Proto_TransactionBody.OneOf_Data {
         let (transactionId, nodeAccountId) = chunkInfo.assertSingleTransaction()
 

--- a/Sources/Hedera/PrivateKey.swift
+++ b/Sources/Hedera/PrivateKey.swift
@@ -170,7 +170,7 @@ public struct PrivateKey: LosslessStringConvertible, ExpressibleByStringLiteral,
         }
 
         switch info.algorithm.oid {
-        case .NamedCurves.ed25519: try self.init(ed25519Bytes: Data(inner.bytes))
+        case .AlgorithmIdentifier.ed25519: try self.init(ed25519Bytes: Data(inner.bytes))
         case .NamedCurves.secp256k1: try self.init(ecdsaBytes: Data(inner.bytes))
         case let oid:
             throw HError.keyParse("unsupported key algorithm: \(oid)")
@@ -225,9 +225,8 @@ public struct PrivateKey: LosslessStringConvertible, ExpressibleByStringLiteral,
     private var algorithm: Pkcs5.AlgorithmIdentifier {
         let oid: ASN1ObjectIdentifier
 
-        // todo: `self.kind`
-        switch self.kind {
-        case .ed25519: oid = .NamedCurves.ed25519
+        switch self.guts {
+        case .ed25519: oid = .AlgorithmIdentifier.ed25519
         case .ecdsa: oid = .NamedCurves.secp256k1
         }
 

--- a/Sources/Hedera/PublicKey.swift
+++ b/Sources/Hedera/PublicKey.swift
@@ -151,9 +151,8 @@ public struct PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, 
     private var algorithm: Pkcs5.AlgorithmIdentifier {
         let oid: ASN1ObjectIdentifier
 
-        // todo: `self.kind`
-        switch self.kind {
-        case .ed25519: oid = .NamedCurves.ed25519
+        switch guts {
+        case .ed25519: oid = .AlgorithmIdentifier.ed25519
         case .ecdsa: oid = .NamedCurves.secp256k1
         }
 
@@ -197,8 +196,6 @@ public struct PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, 
         }
 
         switch info.algorithm.oid {
-        // hack: Rust had a bug where it used the wrong OID for public keys, the only test verifying the correct behavior exists in JS,
-        // rather than Java, where the impl was ported from, the incorrect OID being `id-ecpub`.
         case .NamedCurves.secp256k1,
             .AlgorithmIdentifier.idEcPublicKey where info.algorithm.parametersOID == .NamedCurves.secp256k1:
             guard info.subjectPublicKey.paddingBits == 0 else {
@@ -207,7 +204,7 @@ public struct PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, 
 
             try self.init(ecdsaBytes: Data(info.subjectPublicKey.bytes))
 
-        case .NamedCurves.ed25519:
+        case .AlgorithmIdentifier.ed25519:
             guard info.subjectPublicKey.paddingBits == 0 else {
                 throw HError.keyParse("Invalid padding for ed25519 spki")
             }

--- a/Sources/Hedera/SolidityAddress.swift
+++ b/Sources/Hedera/SolidityAddress.swift
@@ -5,7 +5,7 @@ internal struct SolidityAddress: CustomStringConvertible {
 
     internal init(_ data: Data) throws {
         guard data.count == 20 else {
-            throw HError(kind: .basicParse, description: "expected evm address to have 20 bytes, it had \(data.count)")
+            throw HError.basicParse("expected evm address to have 20 bytes, it had \(data.count)")
         }
 
         self.data = data
@@ -14,7 +14,7 @@ internal struct SolidityAddress: CustomStringConvertible {
     internal init<E: EntityId>(_ id: E) throws {
         guard let shard = UInt32(exactly: id.shard) else {
             // todo: use a proper error kind
-            throw HError(kind: .basicParse, description: "Shard too big for `toSolidityAddress`")
+            throw HError.basicParse("Shard too big for `toSolidityAddress`")
         }
 
         self.data = (shard.bigEndianBytes + id.realm.bigEndianBytes + id.num.bigEndianBytes)
@@ -24,8 +24,7 @@ internal struct SolidityAddress: CustomStringConvertible {
         let description = description.stripPrefix("0x") ?? description[...]
 
         guard let bytes = Data(hexEncoded: description) else {
-            // todo: better error message
-            throw HError(kind: .basicParse, description: "invalid solidity address")
+            throw HError.basicParse("invalid solidity address")
         }
 
         try self.init(bytes)

--- a/Sources/Hedera/Transaction.swift
+++ b/Sources/Hedera/Transaction.swift
@@ -500,7 +500,6 @@ extension Transaction {
         var signatures: [SignaturePair] = []
 
         if let `operator` = self.operator {
-            // todo: avoid the `.map(xyz).collect()`
             let operatorSignature = `operator`.signer(bodyBytes)
 
             signatures.append(SignaturePair(operatorSignature))

--- a/Sources/Hedera/TransactionId.swift
+++ b/Sources/Hedera/TransactionId.swift
@@ -15,7 +15,7 @@ public struct TransactionId: Sendable, Equatable, Hashable, ExpressibleByStringL
     public let scheduled: Bool
     public let nonce: Int32?
 
-    internal init(accountId: AccountId, validStart: Timestamp, scheduled: Bool, nonce: Int32? = nil) {
+    internal init(accountId: AccountId, validStart: Timestamp, scheduled: Bool = false, nonce: Int32? = nil) {
         self.accountId = accountId
         self.validStart = validStart
         self.scheduled = scheduled
@@ -45,7 +45,7 @@ public struct TransactionId: Sendable, Equatable, Hashable, ExpressibleByStringL
         // .stripSuffix("?scheduled") -> ("<validStart>") and the suffix was either removed or not.
         // (except it's better ux to do a `splitOnce('?')`... Except it doesn't matter that much)
         guard let (accountIdStr, rest) = description.splitOnce(on: "@") else {
-            throw HError(kind: .basicParse, description: expected)
+            throw HError.basicParse(expected)
         }
 
         let accountId = try AccountId(parsing: accountIdStr)
@@ -67,7 +67,7 @@ public struct TransactionId: Sendable, Equatable, Hashable, ExpressibleByStringL
         }
 
         guard let (validStartSeconds, validStartNanos) = validStartStr.splitOnce(on: ".") else {
-            throw HError(kind: .basicParse, description: expected)
+            throw HError.basicParse(expected)
         }
 
         let validStart = Timestamp(


### PR DESCRIPTION
**Description**:
Mostly internal refactors with no outward facing changes...
Except:
- change!: `RequestType` no longer has the `.none` variant, instead an Optional (`RequestType?`) should be used.
- change!: `TransactionReceipt.topicRunningHash` is now `Data` instead of a base64 string
- fix: Actually serialize `TransactionReceipt.topicRunningHash` in `toProtobuf` impl (this is something that can be noticed, but it isn't exactly breaking).
Catalog of internal changes for reference purposes:
- refactor: use `HError.basicParse(..)` instead of `HError(kind: basicParse, description: ..)` (they do the same thing but the former is both less likely to mess with IDEs and is shorter)
- change: remove transaction ID from ScheduleMultiSigTransaction example because it isn't actually used (despite it _saying_ it's used and what it's used for), it's like that in all other SDKs, but, A: it's an example, B: it really didn't add anything
- refactor: give the variables in checksum generation full names (after I figured out _what_ those names should be that is)
**Related issue(s)**

- #261 as much as is reasonably possible for now

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
