### PR TITLE
chore: run local node in e2e tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@ OPERATOR_ACCOUNT_ID=
 
 # Default private key to use to sign for all transactions and queries
 OPERATOR_KEY=
+
+# Network names: `"localhost"`, `"testnet"`, `"previewnet"`, `"mainnet"`
+TEST_NETWORK_NAME=
+
+# Enables non-free transactions when testing
+TEST_RUN_NONFREE=1

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -59,5 +59,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.swift }}-spm-
 
+      - name: "Create env file"
+        run: |
+            touch .env
+            echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+            echo TEST_OPERATOR_ID="0.0.2" >> .env
+            echo TEST_HEDERA_NETWORK="localhost" >> .env
+            echo TEST_RUN_NONFREE="1" >> .env
+            cat .env
+      
+      - name: Start the local node
+        run: npx @hashgraph/hedera-local@2.13.0 start -d --network local
+
       - name: Test
         run: swift test
+
+      - name: Stop the local node
+        run: npx @hashgraph/hedera-local@2.13.0 stop

--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ protoc --swift_opt=Visibility=Public --swift_opt=FileNaming=PathToUnderscores --
 protoc --grpc-swift_opt=Visibility=Public,FileNaming=PathToUnderscores,Server=false --grpc-swift_out=./Sources/HederaProtobufs/Mirror -I=protobufs/mirror -I=protobufs/services protobufs/mirror/**.proto
 ```
 
+###  Integration Tests
+Before running the integration tests, an operator key, operator account id, and a network name must be set in an `.env` file. 
+```bash
+# Account that will pay query and transaction fees
+TEST_OPERATOR_ACCOUNT_ID=
+# Default private key to use to sign for all transactions and queries
+TEST_OPERATOR_KEY=
+# Network names: `"localhost"`, `"testnet"`, `"previewnet"`, `"mainnet"`
+TEST_NETWORK_NAME=
+```
+```bash
+# Run tests
+$  swift test 
+```
+
+#### Local Environment Testing
+Hedera offers a way to run tests through your localhost using the `hedera-local-node` service. 
+
+For instructions on how to set up and run local node, follow the steps in the git repository:
+https://github.com/hashgraph/hedera-local-node
+
+Once the local node is running in Docker, the appropriate `.env` values must be set:
+```bash
+TEST_OPERATOR_ACCOUNT_ID=0.0.2
+TEST_OPERATOR_KEY=3030020100300706052b8104000a042204205bc004059ffa2943965d306f2c44d266255318b3775bacfec42a77ca83e998f2
+TEST_NETWORK_NAME=localhost
+```
+Lastly, run the tests using `swift test`
+
 ### Generate SDK
 ```bash
 # cwd: `$REPO/sdk/swift`


### PR DESCRIPTION
**Description**:
- Added local node to e2e tests
- In the README.md, there are instructions on running e2e tests
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:
- https://github.com/hashgraph/hedera-sdk-swift/issues/314
- https://github.com/hashgraph/hedera-sdk-swift/issues/315

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
