### PR TITLE
Fix: multi-chunked transactions contain the same payer account id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Account that will pay query and transaction fees
-OPERATOR_ACCOUNT_ID=
+OPERATOR_ID=
 
 # Default private key to use to sign for all transactions and queries
 OPERATOR_KEY=

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -59,20 +59,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.swift }}-spm-
 
-      - name: "Create env file"
-        run: |
-            touch .env
-            echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-            echo TEST_OPERATOR_ID="0.0.2" >> .env
-            echo TEST_HEDERA_NETWORK="localhost" >> .env
-            echo TEST_RUN_NONFREE="1" >> .env
-            cat .env
-      
-      - name: Start the local node
-        run: npx @hashgraph/hedera-local@2.13.0 start -d --network local
-
       - name: Test
         run: swift test
-
-      - name: Stop the local node
-        run: npx @hashgraph/hedera-local@2.13.0 stop

--- a/Examples/AccountAlias/main.swift
+++ b/Examples/AccountAlias/main.swift
@@ -107,7 +107,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/AccountAllowance/main.swift
+++ b/Examples/AccountAllowance/main.swift
@@ -215,7 +215,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ConsensusPubSub/main.swift
+++ b/Examples/ConsensusPubSub/main.swift
@@ -77,7 +77,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ConsensusPubSubChunked/main.swift
+++ b/Examples/ConsensusPubSubChunked/main.swift
@@ -96,7 +96,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ConsensusPubSubWithSubmitKey/main.swift
+++ b/Examples/ConsensusPubSubWithSubmitKey/main.swift
@@ -83,7 +83,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/CreateAccount/main.swift
+++ b/Examples/CreateAccount/main.swift
@@ -49,7 +49,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/CreateAccountThresholdKey/main.swift
+++ b/Examples/CreateAccountThresholdKey/main.swift
@@ -85,7 +85,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/CreateFile/main.swift
+++ b/Examples/CreateFile/main.swift
@@ -50,7 +50,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/CreateSimpleContract/main.swift
+++ b/Examples/CreateSimpleContract/main.swift
@@ -84,7 +84,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/CreateStatefulContract/main.swift
+++ b/Examples/CreateStatefulContract/main.swift
@@ -101,7 +101,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/CreateTopic/main.swift
+++ b/Examples/CreateTopic/main.swift
@@ -50,7 +50,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/DeleteAccount/main.swift
+++ b/Examples/DeleteAccount/main.swift
@@ -41,7 +41,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/DeleteFile/main.swift
+++ b/Examples/DeleteFile/main.swift
@@ -54,7 +54,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/FileAppendChunked/main.swift
+++ b/Examples/FileAppendChunked/main.swift
@@ -43,7 +43,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/GetAccountInfo/main.swift
+++ b/Examples/GetAccountInfo/main.swift
@@ -42,7 +42,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/GetExchangeRates/main.swift
+++ b/Examples/GetExchangeRates/main.swift
@@ -52,7 +52,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/GetFileContents/main.swift
+++ b/Examples/GetFileContents/main.swift
@@ -42,7 +42,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/MultiAppTransfer/main.swift
+++ b/Examples/MultiAppTransfer/main.swift
@@ -116,7 +116,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/MultiSigOffline/main.swift
+++ b/Examples/MultiSigOffline/main.swift
@@ -80,7 +80,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/Prng/main.swift
+++ b/Examples/Prng/main.swift
@@ -46,7 +46,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/Schedule/main.swift
+++ b/Examples/Schedule/main.swift
@@ -103,7 +103,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ScheduleIdenticalTransaction/main.swift
+++ b/Examples/ScheduleIdenticalTransaction/main.swift
@@ -180,7 +180,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ScheduleMultiSigTransaction/main.swift
+++ b/Examples/ScheduleMultiSigTransaction/main.swift
@@ -127,7 +127,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ScheduledTransactionMultiSigThreshold/main.swift
+++ b/Examples/ScheduledTransactionMultiSigThreshold/main.swift
@@ -122,7 +122,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/ScheduledTransfer/main.swift
+++ b/Examples/ScheduledTransfer/main.swift
@@ -171,7 +171,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/Staking/main.swift
+++ b/Examples/Staking/main.swift
@@ -73,7 +73,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/StakingWithUpdate/main.swift
+++ b/Examples/StakingWithUpdate/main.swift
@@ -91,7 +91,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/TopicWithAdminKey/main.swift
+++ b/Examples/TopicWithAdminKey/main.swift
@@ -97,7 +97,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/TransferCrypto/main.swift
+++ b/Examples/TransferCrypto/main.swift
@@ -47,7 +47,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/TransferTokens/main.swift
+++ b/Examples/TransferTokens/main.swift
@@ -178,7 +178,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/Examples/UpdateAccountPublicKey/main.swift
+++ b/Examples/UpdateAccountPublicKey/main.swift
@@ -53,7 +53,7 @@ internal enum Program {
 extension Environment {
     /// Account ID for the operator to use in this example.
     internal var operatorAccountId: AccountId {
-        AccountId(self["OPERATOR_ACCOUNT_ID"]!.stringValue)!
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
     }
 
     /// Private key for the operator to use in this example.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ protoc --grpc-swift_opt=Visibility=Public,FileNaming=PathToUnderscores,Server=fa
 Before running the integration tests, an operator key, operator account id, and a network name must be set in an `.env` file. 
 ```bash
 # Account that will pay query and transaction fees
-TEST_OPERATOR_ACCOUNT_ID=
+TEST_OPERATOR_ID=
 # Default private key to use to sign for all transactions and queries
 TEST_OPERATOR_KEY=
 # Network names: `"localhost"`, `"testnet"`, `"previewnet"`, `"mainnet"`
@@ -115,7 +115,7 @@ https://github.com/hashgraph/hedera-local-node
 
 Once the local node is running in Docker, the appropriate `.env` values must be set:
 ```bash
-TEST_OPERATOR_ACCOUNT_ID=0.0.2
+TEST_OPERATOR_ID=0.0.2
 TEST_OPERATOR_KEY=3030020100300706052b8104000a042204205bc004059ffa2943965d306f2c44d266255318b3775bacfec42a77ca83e998f2
 TEST_NETWORK_NAME=localhost
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Release process for SWIFT SDK
+
+## Release
+1. Create a new git branch: `release/vX.Y.Z`.
+>- Follows [semver 2.0](https://semver.org/spec/v2.0.0.html)
+2. Run all tests against [hedera-local-node](https://github.com/hashgraph/hedera-local-node). Stop local-node once the tests are completed.
+>- `swift test`
+3. Create a new tag.
+>- `git push -a <version> -m <version>`
+4. Once branch has been approved and merged to main, document added features pertaining to the newest release.
+>- [Tags and Releases for Swift SDK](https://github.com/hashgraph/hedera-sdk-swift/releases)

--- a/Sources/Hedera/PingQuery.swift
+++ b/Sources/Hedera/PingQuery.swift
@@ -65,6 +65,14 @@ extension PingQuery: Execute {
 
     internal var requiresTransactionId: Bool { false }
 
+    internal var firstTransactionId: TransactionId? {
+        nil
+    }
+
+    internal var index: Int? {
+        nil
+    }
+
     internal func makeRequest(_ transactionId: TransactionId?, _ nodeAccountId: AccountId) throws -> (Proto_Query, ()) {
         let header = Proto_QueryHeader.with { $0.responseType = .answerOnly }
 

--- a/Sources/Hedera/Query.swift
+++ b/Sources/Hedera/Query.swift
@@ -209,6 +209,14 @@ extension Query: Execute {
         self.payment.regenerateTransactionId
     }
 
+    internal var firstTransactionId: TransactionId? {
+        payment.firstTransactionId
+    }
+
+    internal var index: Int? {
+        payment.index
+    }
+
     internal func makeRequest(_ transactionId: TransactionId?, _ nodeAccountId: AccountId) throws -> (Proto_Query, ()) {
         let request = toQueryProtobufWith(
             try .with { proto in

--- a/Sources/Hedera/QueryCost.swift
+++ b/Sources/Hedera/QueryCost.swift
@@ -57,6 +57,14 @@ extension QueryCost: Execute {
         false
     }
 
+    internal var firstTransactionId: TransactionId? {
+        nil
+    }
+
+    internal var index: Int? {
+        nil
+    }
+
     internal var requiresTransactionId: Bool { false }
 
     internal func makeRequest(_ transactionId: TransactionId?, _ nodeAccountId: AccountId) throws -> (Proto_Query, ()) {

--- a/Sources/Hedera/Transaction/TransactionSources.swift
+++ b/Sources/Hedera/Transaction/TransactionSources.swift
@@ -140,7 +140,6 @@ internal struct TransactionSources: Sendable {
         (0..<chunksCount).lazy.map { SourceChunk(map: self.guts, index: $0) }
     }
 }
-
 extension TransactionSources {
     // this is every bit as insane as the rust method I ported it from :/
     // swiftlint:disable:next function_body_length
@@ -239,6 +238,7 @@ extension TransactionSources {
 
             for chunk in chunks {
                 let transactionId = transactionInfo[chunk.startIndex].transactionId
+
                 guard !transactionIdsTmp.contains(transactionId) else {
                     throw HError.fromProtobuf("duplicate transaction ID between chunked transaction chunks")
                 }
@@ -417,6 +417,14 @@ extension SourceTransactionExecuteView: Execute {
     }
 
     internal var operatorAccountId: AccountId? {
+        nil
+    }
+
+    internal var firstTransactionId: TransactionId? {
+        nil
+    }
+
+    internal var index: Int? {
         nil
     }
 

--- a/Sources/Hedera/TransactionId.swift
+++ b/Sources/Hedera/TransactionId.swift
@@ -31,6 +31,21 @@ public struct TransactionId: Sendable, Equatable, Hashable, ExpressibleByStringL
         return Self(accountId: accountId, validStart: validStart)
     }
 
+    /// Generates a new transaction ID for chunks.
+    internal static func generateFromInitial(_ initialTransactionId: TransactionId?, _ index: Int?) -> Self? {
+        guard let initialTransactionId = initialTransactionId else {
+            return nil
+        }
+
+        guard let index = index else {
+            return nil
+        }
+
+        return TransactionId(
+            accountId: initialTransactionId.accountId,
+            validStart: initialTransactionId.validStart.adding(nanos: UInt64(index)))
+    }
+
     /// Creates a new transaction Id with the given account id and valid start.
     public static func withValidStart(_ accountId: AccountId, _ validStart: Timestamp) -> Self {
         Self(accountId: accountId, validStart: validStart)

--- a/Tests/HederaE2ETests/Config.swift
+++ b/Tests/HederaE2ETests/Config.swift
@@ -172,7 +172,7 @@ internal struct TestEnvironment {
     private enum Keys {
         fileprivate static let network = "TEST_NETWORK_NAME"
         fileprivate static let operatorKey = "TEST_OPERATOR_KEY"
-        fileprivate static let operatorAccountId = "TEST_OPERATOR_ACCOUNT_ID"
+        fileprivate static let operatorAccountId = "TEST_OPERATOR_ID"
         fileprivate static let runNonfree = "TEST_RUN_NONFREE"
     }
 


### PR DESCRIPTION
**Description**:
- `TransactionId`s for each chunk of a multi-chunked transaction will contain the same `TransactionId.accountId` as the initial `transactionId`. Creating a multi-chunked transaction with account A, then freezing it with account B will yield the same `accountId` for each chunks' `transactionId` regardless.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:
- https://github.com/hashgraph/hedera-sdk-swift/issues/322

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
