### PR TITLE
feat(accountCreateTransaction): Implement JSON-RPC endpoint for `AccountCreateTransaction`

### DIFF
--- a/Sources/Hedera/Account/AccountCreateTransaction.swift
+++ b/Sources/Hedera/Account/AccountCreateTransaction.swift
@@ -283,7 +283,7 @@ extension AccountCreateTransaction: ToProtobuf {
     internal func toProtobuf() -> Protobuf {
         .with { proto in
             key?.toProtobufInto(&proto.key)
-            proto.initialBalance = UInt64(initialBalance.toTinybars())
+            proto.initialBalance = UInt64(truncatingIfNeeded: initialBalance.toTinybars())
             proto.receiverSigRequired = receiverSignatureRequired
             autoRenewPeriod?.toProtobufInto(&proto.autoRenewPeriod)
             // autoRenewAccountId?.toProtobufInto(&proto.autoRenewAccount)
@@ -295,7 +295,7 @@ extension AccountCreateTransaction: ToProtobuf {
             }
 
             if let stakedNodeId = stakedNodeId {
-                proto.stakedNodeID = Int64(stakedNodeId)
+                proto.stakedNodeID = Int64(truncatingIfNeeded: stakedNodeId)
             }
 
             if let stakedAccountId = stakedAccountId {

--- a/Sources/Hedera/Duration.swift
+++ b/Sources/Hedera/Duration.swift
@@ -33,6 +33,6 @@ extension Duration: ProtobufCodable {
     }
 
     internal func toProtobuf() -> Protobuf {
-        .with { proto in proto.seconds = Int64(seconds) }
+        .with { proto in proto.seconds = Int64(truncatingIfNeeded: seconds) }
     }
 }

--- a/Sources/HederaTCK/JSONHelper.swift
+++ b/Sources/HederaTCK/JSONHelper.swift
@@ -1,0 +1,144 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2024 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+internal func getJsonAsString(_ json: JSONObject, _ paramName: String, _ functionName: String) throws -> String {
+    guard let str = json.stringValue else {
+        throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a string.")
+    }
+    return str
+}
+
+internal func getJsonAsInt(_ json: JSONObject, _ paramName: String, _ functionName: String) throws -> Int64 {
+    guard let param = json.intValue else {
+        throw JSONError.invalidParams("\(functionName): \(paramName) MUST be an integer.")
+    }
+    return param
+}
+
+internal func getJsonAsDouble(_ json: JSONObject, _ paramName: String, _ functionName: String) throws -> Double {
+    guard let param = json.doubleValue else {
+        throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a double.")
+    }
+    return param
+}
+
+internal func getJsonAsBoolean(_ json: JSONObject, _ paramName: String, _ functionName: String) throws -> Bool {
+    guard let param = json.boolValue else {
+        throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a boolean.")
+    }
+    return param
+}
+
+internal func getJsonAsList(_ json: JSONObject, _ paramName: String, _ functionName: String) throws -> [JSONObject] {
+    guard let param = json.listValue else {
+        throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a list.")
+    }
+    return param
+}
+
+internal func getJsonAsDict(_ json: JSONObject, _ paramName: String, _ functionName: String) throws -> [String:
+    JSONObject]
+{
+    guard let param = json.dictValue else {
+        throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a dictionary.")
+    }
+    return param
+}
+
+internal func getParam(_ json: JSONObject?, _ paramName: String, _ functionName: String) throws -> JSONObject {
+    return try json ?? { throw JSONError.invalidParams("\(functionName): \(paramName) MUST be provided.") }()
+}
+
+internal func getOptionalStringParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws
+    -> String?
+{
+    return parameters[name] != nil ? try getJsonAsString(parameters[name]!, name, functionName) : nil
+}
+
+internal func getOptionalIntParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws
+    -> Int64?
+{
+    return parameters[name] != nil ? try getJsonAsInt(parameters[name]!, name, functionName) : nil
+}
+
+internal func getOptionalDoubleParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws
+    -> Double?
+{
+    return parameters[name] != nil ? try getJsonAsDouble(parameters[name]!, name, functionName) : nil
+}
+
+internal func getOptionalBooleanParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> Bool?
+{
+    return parameters[name] != nil ? try getJsonAsBoolean(parameters[name]!, name, functionName) : nil
+}
+
+internal func getOptionalListParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws
+    -> [JSONObject]?
+{
+    return parameters[name] != nil ? try getJsonAsList(parameters[name]!, name, functionName) : nil
+}
+
+internal func getOptionalDictParameter(
+    _ name: String, _ parameters: [String: JSONObject], _ functionName: String
+)
+    throws -> [String: JSONObject]?
+{
+    return parameters[name] != nil ? try getJsonAsDict(parameters[name]!, name, functionName) : nil
+}
+
+internal func getRequiredStringParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> String
+{
+    return try getJsonAsString(getParam(parameters[name], name, functionName), name, functionName)
+}
+
+internal func getRequiredIntParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> Int64
+{
+    return try getJsonAsInt(getParam(parameters[name], name, functionName), name, functionName)
+}
+
+internal func getRequiredDoubleParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> Double
+{
+    return try getJsonAsDouble(getParam(parameters[name], name, functionName), name, functionName)
+}
+
+internal func getRequiredBooleanParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> Bool
+{
+    return try getJsonAsBoolean(getParam(parameters[name], name, functionName), name, functionName)
+}
+
+internal func getRequiredListParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> [JSONObject]
+{
+    return try getJsonAsList(getParam(parameters[name], name, functionName), name, functionName)
+}
+
+internal func getRequiredDictParameter(_ name: String, _ parameters: [String: JSONObject], _ functionName: String)
+    throws -> [String: JSONObject]
+{
+    return try getJsonAsDict(getParam(parameters[name], name, functionName), name, functionName)
+}

--- a/Sources/HederaTCK/JSONRPCTypes.swift
+++ b/Sources/HederaTCK/JSONRPCTypes.swift
@@ -72,6 +72,20 @@ internal struct JSONRequest: Decodable {
             self.params = nil
         }
     }
+
+    internal func toDict() -> [String: JSONObject] {
+        var dict = [
+            "jsonrpc": JSONObject.string(jsonRpcVersion),
+            "id": JSONObject.int(Int64(self.id)),
+            "method": JSONObject.string(self.method),
+        ]
+
+        if let params = self.params {
+            dict["params"] = params
+        }
+
+        return dict
+    }
 }
 
 internal struct JSONResponse: Encodable {
@@ -155,7 +169,7 @@ internal enum JSONError: Encodable, Error {
 internal enum JSONObject: Codable {
     case none
     case string(String)
-    case integer(Int)
+    case int(Int64)
     case double(Double)
     case bool(Bool)
     case list([JSONObject])
@@ -167,8 +181,8 @@ internal enum JSONObject: Codable {
         }
         return nil
     }
-    var intValue: Int? {
-        if case .integer(let value) = self {
+    var intValue: Int64? {
+        if case .int(let value) = self {
             return value
         }
         return nil
@@ -203,8 +217,8 @@ internal enum JSONObject: Codable {
 
         if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode(Int.self) {
-            self = .integer(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .int(value)
         } else if let value = try? container.decode(Double.self) {
             self = .double(value)
         } else if let value = try? container.decode(Bool.self) {
@@ -226,7 +240,7 @@ internal enum JSONObject: Codable {
             break
         case .string(let value):
             try container.encode(value)
-        case .integer(let value):
+        case .int(let value):
             try container.encode(value)
         case .double(let value):
             try container.encode(value)

--- a/Sources/HederaTCK/SDKClient.swift
+++ b/Sources/HederaTCK/SDKClient.swift
@@ -23,9 +23,9 @@ import HederaProtobufs
 @testable import Hedera
 
 class SDKClient {
-    var client: Client
+    private var client: Client
 
-    init() {
+    public init() {
         self.client = Client.forTestnet()
     }
 
@@ -39,160 +39,92 @@ class SDKClient {
         case evmAddressKeyType = "evmAddress"
     }
 
-    private func verifyJsonRequestParameters(parameters: JSONObject?, functionName: String) throws -> [String:
-        JSONObject]
-    {
-        /// Parameters MUST be provided.
-        guard let paramsJson = parameters else {
-            throw JSONError.invalidParams("\(functionName): parameters MUST be provided.")
+    private func getHederaKey(_ key: String) throws -> Key {
+        do {
+            return Key.single(try PrivateKey.fromStringDer(key).publicKey)
+        } catch {
+            do {
+                return Key.single(try PublicKey.fromStringDer(key))
+            } catch {
+                return try Key(protobuf: try Proto_Key(serializedData: Data(hex: key)))
+            }
         }
-
-        /// Parameters MUST be a dictionary.
-        guard let paramsAsDictionary = paramsJson.dictValue else {
-            throw JSONError.invalidParams("\(functionName): parameters MUST be a dictionary.")
-        }
-
-        return paramsAsDictionary
     }
 
     private func generateKeyHelper(
         parameters: [String: JSONObject], privateKeys: inout [JSONObject], isList: Bool = false
     ) throws -> String {
-        /// A type MUST be provided.
-        guard let typeJson = parameters["type"] else {
-            throw JSONError.invalidParams("generateKey: type MUST be provided.")
-        }
-
-        /// The type MUST be a string.
-        guard let typeAsString = typeJson.stringValue else {
-            throw JSONError.invalidParams("generateKey: type MUST be a string.")
-        }
-
-        /// The type MUST be recognizable.
-        guard let type = KeyType(rawValue: typeAsString) else {
+        guard let type = KeyType(rawValue: try getRequiredStringParameter("type", parameters, "generateKey")) else {
             throw JSONError.invalidParams(
-                "generateKey: type MUST be one of the valid types.", JSONObject.string(typeAsString))
+                "generateKey: type is NOT a valid value.")
         }
 
-        var fromKey: String?
-        if let fromKeyJson = parameters["fromKey"] {
-            /// fromKey MUST NOT be provided for types that are not ed25519PublicKeyType, ecdsaSecp256k1PublicKeyType, or evmAddressKeyType.
-            if type != .ed25519PublicKeyType, type != .ecdsaSecp256k1PublicKeyType, type != .evmAddressKeyType {
-                throw JSONError.invalidParams(
-                    "generateKey: fromKey MUST NOT be provided for types other than ed25519PublicKey, ecdsaSecp256k1PublicKey, or evmAddress."
-                )
-            }
-
-            /// If provided, fromKey MUST be a string.
-            guard let fromKeyAsString = fromKeyJson.stringValue else {
-                throw JSONError.invalidParams("generateKey: fromKey MUST be a string.")
-            }
-
-            fromKey = fromKeyAsString
+        let fromKey = try getOptionalStringParameter("fromKey", parameters, "generateKey")
+        if fromKey != nil, type != .ed25519PublicKeyType, type != .ecdsaSecp256k1PublicKeyType, type != .evmAddressKeyType {
+            throw JSONError.invalidParams(
+                "generateKey: fromKey MUST NOT be provided for types other than ed25519PublicKey, ecdsaSecp256k1PublicKey, or evmAddress."
+            )
         }
 
-        var threshold: Int?
-        if let thresholdJson = parameters["threshold"] {
-            /// threshold MUST NOT be provided for types that are not thresholdKeyType.
-            if type != .thresholdKeyType {
-                throw JSONError.invalidParams("generateKey: threshold MUST be provided for thresholdKey types.")
-            }
-
-            /// If threshold is provided, it MUST be an int.
-            guard let thresholdAsInt = thresholdJson.intValue else {
-                throw JSONError.invalidParams("generateKey: threshold MUST be an integer.")
-            }
-
-            threshold = thresholdAsInt
-        } else {
-            /// threshold MUST be provided for thresholdKeyTypes.
-            if type == .thresholdKeyType {
-                throw JSONError.invalidParams("generateKey: threshold MUST be provided for thresholdKey types.")
-            }
+        let threshold = try getOptionalIntParameter("threshold", parameters, "generateKey")
+        if threshold != nil, type != .thresholdKeyType {
+            throw JSONError.invalidParams("generateKey: threshold MUST be provided for thresholdKey types.")
+        } else if threshold == nil, type == .thresholdKeyType {
+            throw JSONError.invalidParams("generateKey: threshold MUST be provided for thresholdKey types.")
         }
 
-        var keys: [JSONObject]?
-        if let keyListJson = parameters["keys"] {
-            /// keys MUST NOT be provided for types that are not listKeyType or thresholdKeyType.
-            if type != .listKeyType, type != .thresholdKeyType {
-                throw JSONError.invalidParams(
-                    "generateKey: keys MUST NOT be provided for types other than keyList or thresholdKey.")
-            }
-
-            /// If keys are provided, it MUST be a list.
-            guard let keysAsList = keyListJson.listValue else {
-                throw JSONError.invalidParams("generateKey: keys MUST be a list.")
-            }
-
-            keys = keysAsList
-        } else {
-            /// keys MUST be provided for listKeyTypes and thresholdKeyTypes.
-            if type == .listKeyType || type == .thresholdKeyType {
-                throw JSONError.invalidParams("generateKey: keys MUST be provided for keyList and thresholdKey types.")
-            }
+        let keys = try getOptionalListParameter("keys", parameters, "generateKey")
+        if keys != nil, type != .listKeyType, type != .thresholdKeyType {
+            throw JSONError.invalidParams("generateKey: keys MUST NOT be provided for types other than keyList or thresholdKey.")
+        } else if keys == nil, type == .listKeyType || type == .thresholdKeyType {
+            throw JSONError.invalidParams("generateKey: keys MUST be provided for keyList and thresholdKey types.")
         }
 
         switch type {
         case .ed25519PrivateKeyType, .ecdsaSecp256k1PrivateKeyType:
             let key =
-                (type == .ed25519PublicKeyType)
-                ? PrivateKey.generateEd25519().toStringDer() : PrivateKey.generateEcdsa().toStringDer()
+                ((type == .ed25519PublicKeyType)
+                ? PrivateKey.generateEd25519() : PrivateKey.generateEcdsa()).toStringDer()
 
-            /// If this private key is being generated as part of a KeyList or ThresholdKey, add it to the privateKeys list.
             if isList {
                 privateKeys.append(JSONObject.string(key))
             }
 
             return key
+
         case .ed25519PublicKeyType, .ecdsaSecp256k1PublicKeyType:
-            /// Generate the public key from the fromKey if provided.
             if let fromKey = fromKey {
                 return try PrivateKey.fromStringDer(fromKey).publicKey.toStringDer()
             }
 
             let key = (type == .ed25519PublicKeyType) ? PrivateKey.generateEd25519() : PrivateKey.generateEcdsa()
 
-            /// If this public key is being generated as part of a KeyList or ThresholdKey, add its private key to the privateKeys list.
             if isList {
                 privateKeys.append(JSONObject.string(key.toStringDer()))
             }
 
             return key.publicKey.toStringDer()
+
         case .listKeyType, .thresholdKeyType:
             var keyList: KeyList = []
 
             /// It's guaranteed at this point that keys is provided, so the unwrap can be safely forced.
             for keyJson in keys! {
-                /// The key JSON parameters MUST be a dictionary.
-                guard let keyAsDictionary = keyJson.dictValue else {
-                    throw JSONError.invalidParams("generateKey: key parameters MUST be a dictionary.")
-                }
-
-                /// Recursively call to generate the key in the list of keys. Mark that the key is being generated as part of a list.
-                let generatedKeyString = try generateKeyHelper(
-                    parameters: keyAsDictionary, privateKeys: &privateKeys, isList: true)
-
-                /// Determine the generated key type and add it to the key list.
-                do {
-                    keyList.keys.append(Key.single(try PrivateKey.fromStringDer(generatedKeyString).publicKey))
-                } catch {
-                    do {
-                        keyList.keys.append(Key.single(try PublicKey.fromStringDer(generatedKeyString)))
-                    } catch {
-                        keyList.keys.append(
-                            try Key(protobuf: try Proto_Key(serializedData: Data(hex: generatedKeyString))))
-                    }
-                }
+                keyList.keys.append(
+                    try getHederaKey(
+                        generateKeyHelper(
+                            parameters: getJsonAsDict(keyJson, "keys list key", "generateKey"),
+                            privateKeys: &privateKeys, isList: true)))
             }
 
             if type == KeyType.thresholdKeyType {
-                keyList.threshold = threshold
+                /// It's guaranteed at this point that threshold is provided, so the unwrap can be safely forced.
+                keyList.threshold = Int(threshold!)
             }
 
             return Key.keyList(keyList).toProtobufBytes().toHexString()
 
         case .evmAddressKeyType:
-            /// If fromKey is not provided, generate from a randomly generated ECDSAsecp256k1 key.
             guard let fromKey = fromKey else {
                 return PrivateKey.generateEcdsa().publicKey.toEvmAddress()!.toString()
             }
@@ -210,14 +142,118 @@ class SDKClient {
         }
     }
 
-    func generateKey(parameters: JSONObject?) throws -> JSONObject {
-        /// Verify JSON request parameters exist and are well-formed.
-        let params = try verifyJsonRequestParameters(parameters: parameters, functionName: #function)
+    private func fillOutCommonTransactionParameters<T: Transaction>(
+        _ transaction: inout T, params: [String: JSONObject], client: Client, function: String
+    )
+        throws
+    {
+        if let transactionId = try getOptionalStringParameter("transactionId", params, function) {
+            transaction.transactionId = try TransactionId.fromString(transactionId)
+        }
 
+        if let maxTransactionFee = try getOptionalIntParameter("maxTransactionFee", params, function) {
+            transaction.maxTransactionFee = Hbar.fromTinybars(maxTransactionFee)
+        }
+
+        if let validTransactionDuration = try getOptionalIntParameter("validTransactionDuration", params, function) {
+            transaction.transactionValidDuration = Duration(seconds: UInt64(validTransactionDuration))
+        }
+
+        if let memo = try getOptionalStringParameter("memo", params, function) {
+            transaction.transactionMemo = memo
+        }
+
+        if let regenerateTransactionId = try getOptionalBooleanParameter("regenerateTransactionId", params, function) {
+            transaction.regenerateTransactionId = regenerateTransactionId
+        }
+
+        if let signers = try getOptionalListParameter("signers", params, function) {
+            try transaction.freezeWith(client)
+            for signer in signers {
+                transaction.sign(
+                    try PrivateKey.fromStringDer(getJsonAsString(signer, "signers list element", "generateKey")))
+            }
+        }
+    }
+
+    public func createAccount(_ parameters: [String: JSONObject]?) async throws -> JSONObject {
+        var accountCreateTransaction = AccountCreateTransaction()
+
+        if let params = parameters {
+            if let key = try getOptionalStringParameter("key", params, #function) {
+                accountCreateTransaction.key = try getHederaKey(key)
+            }
+
+            if let initialBalance = try getOptionalIntParameter(
+                "initialBalance", params, #function)
+            {
+                accountCreateTransaction.initialBalance = Hbar.fromTinybars(initialBalance)
+            }
+
+            if let receiverSignatureRequired = try getOptionalBooleanParameter(
+                "receiverSignatureRequired", params, #function)
+            {
+                accountCreateTransaction.receiverSignatureRequired = receiverSignatureRequired
+            }
+
+            if let autoRenewPeriod = try getOptionalIntParameter(
+                "autoRenewPeriod", params, #function)
+            {
+                accountCreateTransaction.autoRenewPeriod = Duration(seconds: UInt64(autoRenewPeriod))
+            }
+
+            if let memo = try getOptionalStringParameter("memo", params, #function) {
+                accountCreateTransaction.accountMemo = memo
+            }
+
+            if let maxAutoTokenAssociations = try getOptionalIntParameter(
+                "maxAutoTokenAssociations", params, #function)
+            {
+                accountCreateTransaction.maxAutomaticTokenAssociations = UInt32(maxAutoTokenAssociations)
+            }
+
+            if let stakedAccountId = try getOptionalStringParameter(
+                "stakedAccountId", params, #function)
+            {
+                accountCreateTransaction.stakedAccountId = try AccountId.fromString(stakedAccountId)
+            }
+
+            if let stakedNodeId = try getOptionalIntParameter(
+                "stakedNodeId", params, #function)
+            {
+                accountCreateTransaction.stakedNodeId = UInt64(stakedNodeId)
+            }
+
+            if let declineStakingReward = try getOptionalBooleanParameter(
+                "declineStakingReward", params, #function)
+            {
+                accountCreateTransaction.declineStakingReward = declineStakingReward
+            }
+
+            if let alias = try getOptionalStringParameter("alias", params, #function) {
+                accountCreateTransaction.alias = try EvmAddress.fromString(alias)
+            }
+
+            if let commonTransactionParams = try getOptionalDictParameter(
+                "commonTransactionParams", params, #function)
+            {
+                try fillOutCommonTransactionParameters(
+                    &accountCreateTransaction, params: commonTransactionParams, client: self.client, function: #function
+                )
+            }
+        }
+
+        let txReceipt = try await accountCreateTransaction.execute(client).getReceipt(client)
+        return JSONObject.dictionary([
+            "accountId": JSONObject.string(txReceipt.accountId!.toString()),
+            "status": JSONObject.string(txReceipt.status.description),
+        ])
+    }
+
+    public func generateKey(_ parameters: [String: JSONObject]) throws -> JSONObject {
         var privateKeys = [JSONObject]()
-        let key = try generateKeyHelper(parameters: params, privateKeys: &privateKeys)
+        let key = try generateKeyHelper(parameters: parameters, privateKeys: &privateKeys)
 
-        /// If private keys were added to the privateKeys list, add the list to the return object.
         if !privateKeys.isEmpty {
             return JSONObject.dictionary(["key": JSONObject.string(key), "privateKeys": JSONObject.list(privateKeys)])
         }
@@ -225,77 +261,37 @@ class SDKClient {
         return JSONObject.dictionary(["key": JSONObject.string(key)])
     }
 
-    func reset() throws -> JSONObject {
+    public func reset() throws -> JSONObject {
         self.client = try Client.forNetwork([String: AccountId]())
         return JSONObject.dictionary(["status": JSONObject.string("SUCCESS")])
     }
 
-    func setup(parameters: JSONObject?) throws -> JSONObject {
-        /// Verify JSON request parameters exist and are well-formed.
-        let params = try verifyJsonRequestParameters(parameters: parameters, functionName: #function)
+    public func setup(_ parameters: [String: JSONObject]) throws -> JSONObject {
+        let operatorAccountId = try AccountId.fromString(
+            getRequiredStringParameter("operatorAccountId", parameters, #function))
+        let operatorPrivateKey = try PrivateKey.fromStringDer(
+            getRequiredStringParameter("operatorPrivateKey", parameters, #function))
 
-        /// The operator account ID MUST be provided.
-        guard let operatorAccountIdJson = params["operatorAccountId"] else {
-            throw JSONError.invalidParams("\(#function): operatorAccountId MUST be provided.")
-        }
-
-        /// The operator account ID MUST be a string.
-        guard let operatorAccountIdAsString = operatorAccountIdJson.stringValue else {
-            throw JSONError.invalidParams("\(#function): operatorAccountId MUST be a string.")
-        }
-
-        let operatorAccountId = try AccountId.fromString(operatorAccountIdAsString)
-
-        /// The operator private key MUST be provided.
-        guard let operatorPrivateKeyJson = params["operatorPrivateKey"] else {
-            throw JSONError.invalidParams("\(#function): operatorAccountId MUST be provided.")
-        }
-
-        /// The operator private key MUST be a string.
-        guard let operatorPrivateKeyAsString = operatorPrivateKeyJson.stringValue else {
-            throw JSONError.invalidParams("\(#function): operatorPrivateKey MUST be a string.")
-        }
-
-        let operatorPrivateKey = try PrivateKey.fromStringDer(operatorPrivateKeyAsString)
-
-        /// All the parameters for a custom network must be provided, or none of them should be provided.
         var clientType: String
-        let nodeIpJson = params["nodeIp"]
-        let nodeAccountIdJson = params["nodeAccountId"]
-        let mirrorNetworkIpJson = params["mirrorNetworkIp"]
+        let nodeIp = try getOptionalStringParameter("nodeIp", parameters, #function)
+        let nodeAccountId = try getOptionalStringParameter("nodeAccountId", parameters, #function)
+        let mirrorNetworkIp = try getOptionalStringParameter("mirrorNetworkIp", parameters, #function)
 
-        if nodeIpJson == nil, nodeAccountIdJson == nil, mirrorNetworkIpJson == nil {
-            /// If none of the parameters were provided, a testnet connection should be established.
+        if nodeIp == nil, nodeAccountId == nil, mirrorNetworkIp == nil {
             self.client = Client.forTestnet()
             clientType = "testnet"
-        } else if nodeIpJson != nil && nodeAccountIdJson != nil && mirrorNetworkIpJson != nil {
-            /// If all the parameters were provided, they MUST be strings.
-            guard let nodeIp = nodeIpJson?.stringValue else {
-                throw JSONError.invalidParams("\(#function): nodeIp MUST be a string.")
-            }
-
-            guard let nodeAccountId = nodeAccountIdJson?.stringValue else {
-                throw JSONError.invalidParams("\(#function): nodeAccountId MUST be a string.")
-            }
-
-            guard let mirrorNetworkIp = mirrorNetworkIpJson?.stringValue else {
-                throw JSONError.invalidParams("\(#function): mirrorNetworkIp MUST be a string.")
-            }
-
-            /// Set the parameters.
+        } else if let nodeIp = nodeIp, let nodeAccountId = nodeAccountId, let mirrorNetworkIp = mirrorNetworkIp {
             self.client = try Client.forNetwork([nodeIp: AccountId.fromString(nodeAccountId)])
             self.client.setMirrorNetwork([mirrorNetworkIp])
             clientType = "custom"
         } else {
             throw JSONError.invalidParams(
-                "\(#function): all custom network parameters (nodeIp, nodeAccountId, mirrorNetworkIp) MUST or MUST NOT all be provided."
+                "\(#function): custom network parameters (nodeIp, nodeAccountId, mirrorNetworkIp) SHALL or SHALL NOT all be provided."
             )
         }
 
-        // The operator can be set.
         self.client.setOperator(operatorAccountId, operatorPrivateKey)
 
-        /// Client setup successful.
         return JSONObject.dictionary([
             "message": JSONObject.string("Successfully setup " + clientType + " client."),
             "success": JSONObject.string("SUCCESS"),

--- a/Sources/HederaTCK/SDKClient.swift
+++ b/Sources/HederaTCK/SDKClient.swift
@@ -199,7 +199,7 @@ class SDKClient {
             if let autoRenewPeriod = try getOptionalIntParameter(
                 "autoRenewPeriod", params, #function)
             {
-                accountCreateTransaction.autoRenewPeriod = Duration(seconds: UInt64(autoRenewPeriod))
+                accountCreateTransaction.autoRenewPeriod = Duration(seconds: UInt64(truncatingIfNeeded: autoRenewPeriod))
             }
 
             if let memo = try getOptionalStringParameter("memo", params, #function) {
@@ -221,7 +221,7 @@ class SDKClient {
             if let stakedNodeId = try getOptionalIntParameter(
                 "stakedNodeId", params, #function)
             {
-                accountCreateTransaction.stakedNodeId = UInt64(stakedNodeId)
+                accountCreateTransaction.stakedNodeId = UInt64(truncatingIfNeeded: stakedNodeId)
             }
 
             if let declineStakingReward = try getOptionalBooleanParameter(

--- a/Sources/HederaTCK/main.swift
+++ b/Sources/HederaTCK/main.swift
@@ -105,7 +105,7 @@ struct TCKServer {
                 .receiptStatus(let status, let _):
                 return JSONResponse(id: request.id, error: JSONError.hederaError("Hedera error", JSONObject.dictionary(["status": JSONObject.string(Status.nameMap[status.rawValue]!), "message": JSONObject.string(error.description)])))
             default:
-                return JSONResponse(id: request.id, error: JSONError.hederaError("Hedera error"))
+                return JSONResponse(id: request.id, error: JSONError.internalError("\(error)"))
             }
         } catch let error {
             return JSONResponse(id: request.id, error: JSONError.internalError("\(error)"))


### PR DESCRIPTION
**Description**:
This PR adds the JSON-RPC `createAccount` to service `AccountCreateTransaction` TCK tests. It also adds some functions for common functionality such as getting optional/required parameters from the JSON-RPC request.

**Related issue(s)**:

Fixes #364 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
