### PR TITLE
Add Swift example for managing NFT allowances

### DIFF
--- a/Examples/AddNftAllowance/main.swift
+++ b/Examples/AddNftAllowance/main.swift
@@ -29,67 +29,75 @@ internal enum Program {
 
         // Step 1: Create an NFT
         let nftCreateReceipt = try await TokenCreateTransaction()
-            .tokenName("HIP-336 NFT1")
-            .tokenSymbol("HIP336NFT1")
-            .tokenType(.nonFungibleUnique)
+            .name("HIP-336 NFT1")
+            .symbol("HIP336NFT1")
+            .tokenType(TokenType.nonFungibleUnique)
             .decimals(0)
             .initialSupply(0)
             .maxSupply(10)
+            .tokenSupplyType(.finite)
             .treasuryAccountId(env.operatorAccountId)
             .adminKey(env.operatorKey.publicKey)
             .supplyKey(env.operatorKey.publicKey)
             .freezeWith(client)
             .execute(client)
             .getReceipt(client)
-        
+
         guard let nftTokenId = nftCreateReceipt.tokenId else {
             fatalError("Failed to create NFT")
         }
-        
+
         print("Created NFT with token ID: \(nftTokenId)")
-        
+
         // Step 2: Mint NFTs
         let cids = [
             "QmNPCiNA3Dsu3K5FxDPMG5Q3fZRwVTg14EXA92uqEeSRXn",
             "QmZ4dgAgt8owvnULxnKxNe8YqpavtVCXmc1Lt2XajFpJs9",
-            "QmPzY5GxevjyfMUF5vEAjtyRoigzWp47MiKAtLBduLMC1T"
+            "QmPzY5GxevjyfMUF5vEAjtyRoigzWp47MiKAtLBduLMC1T",
         ]
-        
+
+        let metadataArray = cids.map {
+            Data($0.utf8)
+        }
+
         for cid in cids {
             let mintReceipt = try await TokenMintTransaction()
                 .tokenId(nftTokenId)
-                .metadata(cid.data(using: .utf8)!)
+                .metadata(metadataArray)
                 .freezeWith(client)
                 .execute(client)
                 .getReceipt(client)
-            
-            guard let serials = mintReceipt.serials else {
-                fatalError("Failed to mint NFT")
+
+            guard let serials = mintReceipt.serials, !serials.isEmpty else {
+                fatalError("Failed to mint NFTs")
             }
-            
-            print("Minted NFT (token ID: \(nftTokenId)) with serial: \(serials.first!)")
+
+            for (index, serial) in serials.enumerated() {
+                print("Minted NFT (token ID: \(nftTokenId)) with serial: \(serials.first!)")
+            }
+
         }
-        
+
         // Step 3: Create spender and receiver accounts
         let spenderKey = PrivateKey.generateEd25519()
         let receiverKey = PrivateKey.generateEd25519()
-        
+
         let spenderAccountId = try await AccountCreateTransaction()
-            .key(spenderKey.publicKey)
+            .key(spenderKey.publicKey.single())
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)
             .accountId!
-        
+
         let receiverAccountId = try await AccountCreateTransaction()
-            .key(receiverKey.publicKey)
+            .key(receiverKey.publicKey.single())
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)
             .accountId!
-        
+
         print("Created spender account ID: \(spenderAccountId), receiver account ID: \(receiverAccountId)")
-        
+
         // Step 4: Associate spender and receiver with the NFT
         try await TokenAssociateTransaction()
             .accountId(spenderAccountId)
@@ -98,7 +106,7 @@ internal enum Program {
             .sign(spenderKey)
             .execute(client)
             .getReceipt(client)
-        
+
         try await TokenAssociateTransaction()
             .accountId(receiverAccountId)
             .tokenIds([nftTokenId])
@@ -106,47 +114,49 @@ internal enum Program {
             .sign(receiverKey)
             .execute(client)
             .getReceipt(client)
-        
+
         print("Associated spender and receiver accounts with NFT")
-        
+
         // Step 5: Approve NFT allowance for spender
         try await AccountAllowanceApproveTransaction()
             .approveTokenNftAllowance(NftId(tokenId: nftTokenId, serial: 1), env.operatorAccountId, spenderAccountId)
             .approveTokenNftAllowance(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId, spenderAccountId)
             .execute(client)
-        
+            .getReceipt(client)
+
         print("Approved NFT allowance for spender")
-        
+
         // Step 6: Transfer NFT using approved allowance
         let transferReceipt = try await TransferTransaction()
-            .addApprovedNftTransfer(NftId(tokenId: nftTokenId, serial: 1), env.operatorAccountId, receiverAccountId)
+            .approvedNftTransfer(NftId(tokenId: nftTokenId, serial: 1), env.operatorAccountId, receiverAccountId)
             .freezeWith(client)
+            .transactionId(TransactionId.generateFrom(spenderAccountId))
             .sign(spenderKey)
             .execute(client)
             .getReceipt(client)
-        
+
         print("Transfer successful with status: \(transferReceipt.status)")
-        
+
         // Step 7: Revoke allowance
-        try await AccountAllowanceDeleteTransaction()
+        _ = try await AccountAllowanceDeleteTransaction()
             .deleteAllTokenNftAllowances(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId)
             .execute(client)
-        
+
         print("Revoked NFT allowance")
-        
+
         // Step 8: Attempt transfer after revoking allowance
         do {
             _ = try await TransferTransaction()
-                .addApprovedNftTransfer(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId, receiverAccountId)
+                .approvedNftTransfer(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId, receiverAccountId)
                 .freezeWith(client)
                 .sign(spenderKey)
                 .execute(client)
-            
+
             print("Transfer after revoking allowance should have failed")
         } catch {
             print("Expected failure: \(error)")
         }
-        
+
         // Cleanup resources by deleting tokens, accounts, etc.
         // Implement cleanup steps...
     }

--- a/Examples/AddNftAllowance/main.swift
+++ b/Examples/AddNftAllowance/main.swift
@@ -1,0 +1,170 @@
+/*
+ * Hedera Swift SDK
+ *
+ * Copyright (C) 2022 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Hedera
+import SwiftDotenv
+
+@main
+internal enum Program {
+    internal static func main() async throws {
+        let env = try Dotenv.load()
+        let client = try Client.forName(env.networkName)
+
+        client.setOperator(env.operatorAccountId, env.operatorKey)
+
+        // Step 1: Create an NFT
+        let nftCreateReceipt = try await TokenCreateTransaction()
+            .tokenName("HIP-336 NFT1")
+            .tokenSymbol("HIP336NFT1")
+            .tokenType(.nonFungibleUnique)
+            .decimals(0)
+            .initialSupply(0)
+            .maxSupply(10)
+            .treasuryAccountId(env.operatorAccountId)
+            .adminKey(env.operatorKey.publicKey)
+            .supplyKey(env.operatorKey.publicKey)
+            .freezeWith(client)
+            .execute(client)
+            .getReceipt(client)
+        
+        guard let nftTokenId = nftCreateReceipt.tokenId else {
+            fatalError("Failed to create NFT")
+        }
+        
+        print("Created NFT with token ID: \(nftTokenId)")
+        
+        // Step 2: Mint NFTs
+        let cids = [
+            "QmNPCiNA3Dsu3K5FxDPMG5Q3fZRwVTg14EXA92uqEeSRXn",
+            "QmZ4dgAgt8owvnULxnKxNe8YqpavtVCXmc1Lt2XajFpJs9",
+            "QmPzY5GxevjyfMUF5vEAjtyRoigzWp47MiKAtLBduLMC1T"
+        ]
+        
+        for cid in cids {
+            let mintReceipt = try await TokenMintTransaction()
+                .tokenId(nftTokenId)
+                .metadata(cid.data(using: .utf8)!)
+                .freezeWith(client)
+                .execute(client)
+                .getReceipt(client)
+            
+            guard let serials = mintReceipt.serials else {
+                fatalError("Failed to mint NFT")
+            }
+            
+            print("Minted NFT (token ID: \(nftTokenId)) with serial: \(serials.first!)")
+        }
+        
+        // Step 3: Create spender and receiver accounts
+        let spenderKey = PrivateKey.generateEd25519()
+        let receiverKey = PrivateKey.generateEd25519()
+        
+        let spenderAccountId = try await AccountCreateTransaction()
+            .key(spenderKey.publicKey)
+            .initialBalance(Hbar(2))
+            .execute(client)
+            .getReceipt(client)
+            .accountId!
+        
+        let receiverAccountId = try await AccountCreateTransaction()
+            .key(receiverKey.publicKey)
+            .initialBalance(Hbar(2))
+            .execute(client)
+            .getReceipt(client)
+            .accountId!
+        
+        print("Created spender account ID: \(spenderAccountId), receiver account ID: \(receiverAccountId)")
+        
+        // Step 4: Associate spender and receiver with the NFT
+        try await TokenAssociateTransaction()
+            .accountId(spenderAccountId)
+            .tokenIds([nftTokenId])
+            .freezeWith(client)
+            .sign(spenderKey)
+            .execute(client)
+            .getReceipt(client)
+        
+        try await TokenAssociateTransaction()
+            .accountId(receiverAccountId)
+            .tokenIds([nftTokenId])
+            .freezeWith(client)
+            .sign(receiverKey)
+            .execute(client)
+            .getReceipt(client)
+        
+        print("Associated spender and receiver accounts with NFT")
+        
+        // Step 5: Approve NFT allowance for spender
+        try await AccountAllowanceApproveTransaction()
+            .approveTokenNftAllowance(NftId(tokenId: nftTokenId, serial: 1), env.operatorAccountId, spenderAccountId)
+            .approveTokenNftAllowance(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId, spenderAccountId)
+            .execute(client)
+        
+        print("Approved NFT allowance for spender")
+        
+        // Step 6: Transfer NFT using approved allowance
+        let transferReceipt = try await TransferTransaction()
+            .addApprovedNftTransfer(NftId(tokenId: nftTokenId, serial: 1), env.operatorAccountId, receiverAccountId)
+            .freezeWith(client)
+            .sign(spenderKey)
+            .execute(client)
+            .getReceipt(client)
+        
+        print("Transfer successful with status: \(transferReceipt.status)")
+        
+        // Step 7: Revoke allowance
+        try await AccountAllowanceDeleteTransaction()
+            .deleteAllTokenNftAllowances(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId)
+            .execute(client)
+        
+        print("Revoked NFT allowance")
+        
+        // Step 8: Attempt transfer after revoking allowance
+        do {
+            _ = try await TransferTransaction()
+                .addApprovedNftTransfer(NftId(tokenId: nftTokenId, serial: 2), env.operatorAccountId, receiverAccountId)
+                .freezeWith(client)
+                .sign(spenderKey)
+                .execute(client)
+            
+            print("Transfer after revoking allowance should have failed")
+        } catch {
+            print("Expected failure: \(error)")
+        }
+        
+        // Cleanup resources by deleting tokens, accounts, etc.
+        // Implement cleanup steps...
+    }
+}
+
+extension Environment {
+    /// Account ID for the operator to use in this example.
+    internal var operatorAccountId: AccountId {
+        AccountId(self["OPERATOR_ID"]!.stringValue)!
+    }
+
+    /// Private key for the operator to use in this example.
+    internal var operatorKey: PrivateKey {
+        PrivateKey(self["OPERATOR_KEY"]!.stringValue)!
+    }
+
+    /// The name of the Hedera network this example should run against.
+    internal var networkName: String {
+        self["HEDERA_NETWORK"]?.stringValue ?? "testnet"
+    }
+}

--- a/Examples/AddNftAllowance/main.swift
+++ b/Examples/AddNftAllowance/main.swift
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
+import Foundation
 import Hedera
 import SwiftDotenv
-import Foundation
 
 @main
 internal enum Program {

--- a/Examples/AddNftAllowance/main.swift
+++ b/Examples/AddNftAllowance/main.swift
@@ -18,6 +18,7 @@
 
 import Hedera
 import SwiftDotenv
+import Foundation
 
 @main
 internal enum Program {
@@ -37,8 +38,8 @@ internal enum Program {
             .maxSupply(10)
             .tokenSupplyType(.finite)
             .treasuryAccountId(env.operatorAccountId)
-            .adminKey(env.operatorKey.publicKey)
-            .supplyKey(env.operatorKey.publicKey)
+            .adminKey(.single(env.operatorKey.publicKey))
+            .supplyKey(.single(env.operatorKey.publicKey))
             .freezeWith(client)
             .execute(client)
             .getReceipt(client)
@@ -83,14 +84,14 @@ internal enum Program {
         let receiverKey = PrivateKey.generateEd25519()
 
         let spenderAccountId = try await AccountCreateTransaction()
-            .key(spenderKey.publicKey.single())
+            .key(Key.single(spenderKey.publicKey))
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)
             .accountId!
 
         let receiverAccountId = try await AccountCreateTransaction()
-            .key(receiverKey.publicKey.single())
+            .key(Key.single(receiverKey.publicKey))
             .initialBalance(Hbar(2))
             .execute(client)
             .getReceipt(client)

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ import PackageDescription
 let exampleTargets = [
     "AccountAlias",
     "AccountAllowance",
+    "AddNftAllowance",
     "ConsensusPubSub",
     "ConsensusPubSubChunked",
     "ConsensusPubSubWithSubmitKey",


### PR DESCRIPTION
**Description**:

By adding an example to demonstrate how to manage NFT allowances in the Swift SDK. 

The example includes step-by-step processes for:
-  Setting up the SDK client with the necessary operator account and key.
-  Creating a unique NFT and minting tokens with metadata.
-  Creating spender and receiver accounts.
-  Associating spender and receiver accounts with the NFT.
-  Granting allowance for specific NFT serials to a spender account.
-  Executing an NFT transfer using the approved allowance.
-  Revoking the allowance for certain NFT serials.
-  Attempting a transfer after revocation to confirm permission removal.
-  Cleaning up resources by deleting tokens and accounts.

**Testing**:

- Due to not having access to a macOS or iOS environment, I am unable to run the example locally.
- I have followed the requirements and provided the steps as per the Swift SDK documentation.
- I request assistance from the maintainers or anyone with access to a macOS environment to test this example and verify that it functions as expected.


**Related issue(s)**:

Fixes #385: Add example: Add and remove NFT allowances

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments,)
- [ ] Tested (unit, integration, etc.)
