### PR TITLE
feat(TCK): Implement JSON-RPC endpoint for `AccountUpdateTransaction`

### DIFF
--- a/Sources/Hedera/Timestamp.swift
+++ b/Sources/Hedera/Timestamp.swift
@@ -88,8 +88,8 @@ extension Timestamp: ProtobufCodable {
 
     internal func toProtobuf() -> Protobuf {
         .with { proto in
-            proto.seconds = Int64(seconds)
-            proto.nanos = Int32(subSecondNanos)
+            proto.seconds = Int64(truncatingIfNeeded: seconds)
+            proto.nanos = Int32(truncatingIfNeeded: subSecondNanos)
         }
     }
 }

--- a/Sources/HederaTCK/JSONHelper.swift
+++ b/Sources/HederaTCK/JSONHelper.swift
@@ -26,29 +26,25 @@ internal func getJson<T>(_ json: JSONObject, _ paramName: String, _ functionName
         }
         return val as! T
     }
-    if T.self == Int32.self
-    {
+    if T.self == Int32.self {
         guard let val = json.intValue else {
             throw JSONError.invalidParams("\(functionName): \(paramName) MUST be an int32.")
         }
         return Int32(truncatingIfNeeded: val) as! T
     }
-    if T.self == UInt32.self
-    {
+    if T.self == UInt32.self {
         guard let val = json.intValue else {
             throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a uint32.")
         }
         return UInt32(truncatingIfNeeded: val) as! T
     }
-    if T.self == Int64.self
-    {
+    if T.self == Int64.self {
         guard let val = json.intValue else {
             throw JSONError.invalidParams("\(functionName): \(paramName) MUST be an int64.")
         }
         return val as! T
     }
-    if T.self == UInt64.self
-    {
+    if T.self == UInt64.self {
         guard let val = json.intValue else {
             throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a uint64.")
         }

--- a/Sources/HederaTCK/JSONHelper.swift
+++ b/Sources/HederaTCK/JSONHelper.swift
@@ -26,13 +26,33 @@ internal func getJson<T>(_ json: JSONObject, _ paramName: String, _ functionName
         }
         return val as! T
     }
-    if T.self == Int.self || T.self == Int32.self || T.self == UInt32.self || T.self == Int64.self
-        || T.self == UInt64.self
+    if T.self == Int32.self
     {
         guard let val = json.intValue else {
-            throw JSONError.invalidParams("\(functionName): \(paramName) MUST be an integer.")
+            throw JSONError.invalidParams("\(functionName): \(paramName) MUST be an int32.")
+        }
+        return Int32(truncatingIfNeeded: val) as! T
+    }
+    if T.self == UInt32.self
+    {
+        guard let val = json.intValue else {
+            throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a uint32.")
+        }
+        return UInt32(truncatingIfNeeded: val) as! T
+    }
+    if T.self == Int64.self
+    {
+        guard let val = json.intValue else {
+            throw JSONError.invalidParams("\(functionName): \(paramName) MUST be an int64.")
         }
         return val as! T
+    }
+    if T.self == UInt64.self
+    {
+        guard let val = json.intValue else {
+            throw JSONError.invalidParams("\(functionName): \(paramName) MUST be a uint64.")
+        }
+        return UInt64(truncatingIfNeeded: val) as! T
     }
     if T.self == Double.self || T.self == Float.self {
         guard let val = json.doubleValue else {

--- a/Sources/HederaTCK/SDKClient.swift
+++ b/Sources/HederaTCK/SDKClient.swift
@@ -71,7 +71,7 @@ internal class SDKClient {
             )
         }
 
-        let threshold: Int? = try getOptionalJsonParameter("threshold", parameters, "generateKey")
+        let threshold: Int64? = try getOptionalJsonParameter("threshold", parameters, "generateKey")
         if threshold != nil, type != .thresholdKeyType {
             throw JSONError.invalidParams(
                 "generateKey: threshold MUST NOT be provided for types other than thresholdKey.")
@@ -309,5 +309,79 @@ internal class SDKClient {
             "success": JSONObject.string("SUCCESS"),
         ])
 
+    }
+
+    internal func updateAccount(_ parameters: [String: JSONObject]?) async throws -> JSONObject {
+        var accountUpdateTransaction = AccountUpdateTransaction()
+
+        if let params = parameters {
+            if let accountId: String = try getOptionalJsonParameter("accountId", params, #function) {
+                accountUpdateTransaction.accountId = try AccountId.fromString(accountId)
+            }
+
+            if let key: String = try getOptionalJsonParameter("key", params, #function) {
+                accountUpdateTransaction.key = try getHederaKey(key)
+            }
+
+            if let autoRenewPeriod: Int64 = try getOptionalJsonParameter(
+                "autoRenewPeriod", params, #function)
+            {
+                accountUpdateTransaction.autoRenewPeriod = Duration(
+                    seconds: UInt64(truncatingIfNeeded: autoRenewPeriod))
+            }
+
+            if let expirationTime: Int64 = try getOptionalJsonParameter("expirationTime", params, #function) {
+                accountUpdateTransaction.expirationTime = Timestamp(
+                    seconds: UInt64(truncatingIfNeeded: expirationTime), subSecondNanos: 0)
+            }
+
+            if let receiverSignatureRequired: Bool = try getOptionalJsonParameter(
+                "receiverSignatureRequired", params, #function)
+            {
+                accountUpdateTransaction.receiverSignatureRequired = receiverSignatureRequired
+            }
+
+            if let memo: String = try getOptionalJsonParameter("memo", params, #function) {
+                accountUpdateTransaction.accountMemo = memo
+            }
+
+            if let maxAutoTokenAssociations: Int64 = try getOptionalJsonParameter(
+                "maxAutoTokenAssociations", params, #function)
+            {
+                accountUpdateTransaction.maxAutomaticTokenAssociations =
+                    Int32(truncatingIfNeeded: maxAutoTokenAssociations)
+            }
+
+            if let stakedAccountId: String = try getOptionalJsonParameter(
+                "stakedAccountId", params, #function)
+            {
+                accountUpdateTransaction.stakedAccountId = try AccountId.fromString(stakedAccountId)
+            }
+
+            if let stakedNodeId: Int64 = try getOptionalJsonParameter(
+                "stakedNodeId", params, #function)
+            {
+                accountUpdateTransaction.stakedNodeId = UInt64(truncatingIfNeeded: stakedNodeId)
+            }
+
+            if let declineStakingReward: Bool = try getOptionalJsonParameter(
+                "declineStakingReward", params, #function)
+            {
+                accountUpdateTransaction.declineStakingReward = declineStakingReward
+            }
+
+            if let commonTransactionParams: [String: JSONObject] = try getOptionalJsonParameter(
+                "commonTransactionParams", params, #function)
+            {
+                try fillOutCommonTransactionParameters(
+                    &accountUpdateTransaction, params: commonTransactionParams, client: self.client, function: #function
+                )
+            }
+        }
+
+        let txReceipt = try await accountUpdateTransaction.execute(client).getReceipt(client)
+        return JSONObject.dictionary([
+            "status": JSONObject.string(txReceipt.status.description)
+        ])
     }
 }

--- a/Sources/HederaTCK/SDKClient.swift
+++ b/Sources/HederaTCK/SDKClient.swift
@@ -372,11 +372,10 @@ internal class SDKClient {
                 accountUpdateTransaction.accountMemo = memo
             }
 
-            if let maxAutoTokenAssociations: Int64 = try getOptionalJsonParameter(
+            if let maxAutoTokenAssociations: Int32 = try getOptionalJsonParameter(
                 "maxAutoTokenAssociations", params, #function)
             {
-                accountUpdateTransaction.maxAutomaticTokenAssociations =
-                    Int32(truncatingIfNeeded: maxAutoTokenAssociations)
+                accountUpdateTransaction.maxAutomaticTokenAssociations = maxAutoTokenAssociations
             }
 
             if let stakedAccountId: String = try getOptionalJsonParameter(

--- a/Sources/HederaTCK/main.swift
+++ b/Sources/HederaTCK/main.swift
@@ -88,6 +88,14 @@ private struct TCKServer {
                     id: request.id,
                     result: try sdkClient.setup(getRequiredJsonParameter("params", request.toDict(), request.method)))
             ///
+            /// updateAccount
+            ///
+            case "updateAccount":
+                return JSONResponse(
+                    id: request.id,
+                    result: try await sdkClient.updateAccount(
+                        getOptionalJsonParameter("params", request.toDict(), request.method)))
+            ///
             /// Method Not Found
             ///
             default:


### PR DESCRIPTION
**Description**:
This PR adds the JSON-RPC `updateAccount` to service `AccountUpdateTransaction` TCK tests. A tweak was made to the SDK itself as well to allow `Timestamp`s to parse unsigned integers to protobuf fields.

**Related issue(s)**:

Fixes #403 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
