### PR TITLE
docs: Update README and documentation with improved formatting and accuracy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,8 +16,8 @@ Maintainers are assigned the following scopes in this repository:
 
 |      Name      |  GitHub ID  | Scope      | LFID | Discord ID | Email | Company Affiliation |
 |--------------- | ----------- | ---------- | ---- | ---------- | ----- | ------------------- |
-| Rob Walworth   | rwalworth   | Maintainer |      |            |       | Hashgraph           |
-| Simi Hunjan    | SimiHunjan  | Maintainer |      |            |       | Hashgraph           |
+| Rob Walworth   | rwalworth   | Maintainer |      | robert.walworth | robert.walworth@swirldslabs.com | Hashgraph |
+| Simi Hunjan    | SimiHunjan  | Maintainer |      | simihunjan | simi@swirldslabs.com | Hashgraph |
 
 
 ## Emeritus Maintainers

--- a/README.md
+++ b/README.md
@@ -2,139 +2,176 @@
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hiero-ledger/hiero-sdk-swift/badge)](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-sdk-swift)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/10697/badge)](https://bestpractices.coreinfrastructure.org/projects/10697)
-[![License](https://img.shields.io/badge/license-apache2-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-The SDK for interacting with a Hiero based network.
+The Swift SDK for interacting with [Hiero](https://hiero.org)-based networks.
 
-<sub>Maintained with ❤️ by <a href="https://launchbadge.com" target="_blank">LaunchBadge</a>, <a href="https://www.hashgraph.com/" target="_blank">Hashgraph</a>, and the Hiero community</sub>
+<sub>Maintained with ❤️ by <a href="https://www.hashgraph.com/" target="_blank">Hashgraph</a> and the <a href="https://hiero.org" target="_blank">Hiero</a> community.</sub>
 
-## Usage
+---
 
-### Requirements
+## Table of Contents
 
-- Swift v5.6+
-- MacOS v10.15+ (2019, Catalina)
-- iOS 13+ (2019)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Development](#development)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [Community](#community)
+- [License](#license)
 
-### Install
+---
+
+## Requirements
+
+| Platform | Minimum Version |
+|----------|-----------------|
+| Swift    | 5.6+            |
+| macOS    | 10.15+ (Catalina, 2019) |
+| iOS      | 13+ (2019)      |
+
+---
+
+## Installation
+
+Add the Hiero SDK to your Swift package dependencies:
 
 ```swift
 // Package.swift
 dependencies: [
-    .package(url: "https://github.com/hiero-project/hiero-sdk-swift.git", from: "0.36.0")
+    .package(url: "https://github.com/hiero-ledger/hiero-sdk-swift.git", from: "0.36.0")
 ]
 ```
 
-See ["Adding Package Dependencies to Your App"](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) for help on
-adding a swift package to an Xcode project.
+For Xcode projects, see Apple's guide on [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app).
 
-### Add to Code 
+---
+
+## Quick Start
 
 ```swift
 import Hiero
 
-// connect to the Hedera network
+// Connect to a Hiero network (testnet, mainnet, etc.)
 let client = Client.forTestnet()
 
-// query the balance of an account
-let ab = try await AccountBalanceQuery()
+// Query the balance of an account
+let balance = try await AccountBalanceQuery()
     .accountId(AccountId("0.0.1001")!)
     .execute(client)
 
-print("balance = \(ab.balance)")
+print("Balance: \(balance.hbars)")
 ```
 
-## Development (HieroProtobufs)
+---
 
-HieroProtobufs are entirely generated.
+## Examples
 
-### Required Tooling
-
-protoc
-protoc-gen-swift (from https://github.com/apple/swift-protobuf)
-protoc-gen-grpc-swift (from https://github.com/grpc/grpc-swift)
-task (from https://github.com/go-task/task)
-openSSL 3.4 (from https://openssl-library.org/source/)
-
-### Fetch Submodule and Generate Swift Protobufs (HieroProtobufs)
-
-Update [\protobufs](https://github.com/hiero-ledger/hiero-consensus-node.git) submodule to latest changes.
-
-```bash
-# Fetch the latest version of the services submodule
-# and generate swift code for Hiero protobufs and gRPC.
-#
-# Note: Append "proto=vX.Y.Z" to fetch a specific version
-task submodule:fetch 
-
-# e.g. move submodule to v0.61.0 tag
-task submodule:fetch proto=v0.61.0
-```
-
-### Examples
-See [examples](./Examples) for more usage.
+The SDK includes example applications in the [Examples](./Examples) directory demonstrating accounts, tokens, consensus topics, files, smart contracts, scheduling, and more.
 
 ```bash
 # Run an example
-$  task example name=<example>
+task example name=<ExampleName>
 
-# e.g CreateAccount
-$  task example name=CreateAccount
-
+# For example:
+task example name=CreateAccount
+task example name=GetAccountBalance
 ```
 
-### Testing
+---
+
+## Development
+
+### Required Tooling
+
+| Tool | Source |
+|------|--------|
+| `protoc` | [Protocol Buffers](https://github.com/protocolbuffers/protobuf) compiler |
+| `protoc-gen-swift` | [apple/swift-protobuf](https://github.com/apple/swift-protobuf) |
+| `protoc-gen-grpc-swift` | [grpc/grpc-swift](https://github.com/grpc/grpc-swift) |
+| `task` | [go-task/task](https://github.com/go-task/task) |
+| `python3` | For proto generation scripts |
+
+### Generating Protobufs
+
+The `HieroProtobufs` module is entirely generated from the [hiero-consensus-node](https://github.com/hiero-ledger/hiero-consensus-node) protobufs.
+
+```bash
+# Fetch the latest protobufs and generate Swift code
+task submodule:fetch
+
+# Or fetch a specific version
+task submodule:fetch proto=v0.61.0
+```
+
+---
+
+## Testing
 
 See [Tests/README.md](./Tests/README.md) for comprehensive testing documentation.
 
-**Quick Start:**
+### Quick Start
 
 ```bash
 # Unit tests (no network required)
 swift test --filter HieroUnitTests
 
-# Integration tests (requires .env configuration)
+# Integration tests (requires environment configuration)
 swift test --filter HieroIntegrationTests
 
 # All tests
 swift test
 
-# Specific test
+# Run a specific test
 swift test --filter AccountCreateTransactionUnitTests/test_Serialize
 ```
 
-**Environment Setup for Integration Tests:**
+### Environment Configuration
 
-Create a `.env` file in the project root:
+Create a `.env` file in the project root for integration tests:
 
 ```bash
+# Required: Operator account credentials
 HIERO_OPERATOR_ID=0.0.1234
 HIERO_OPERATOR_KEY=302e020100300506032b657004220420...
+
+# Environment type: testnet, previewnet, mainnet, or custom
 HIERO_ENVIRONMENT_TYPE=testnet
 ```
 
-**Local Node Testing:**
+### Testing with Solo
 
-For testing against [hiero-local-node](https://github.com/hiero-ledger/hiero-local-node):
+For local development and testing, we recommend using [Hiero Solo](https://github.com/hiero-ledger/solo). Solo provides a lightweight, local Hiero network running in Kubernetes.
 
 ```bash
+# Solo environment configuration
 HIERO_OPERATOR_ID=0.0.2
 HIERO_OPERATOR_KEY=3030020100300706052b8104000a042204205bc004059ffa2943965d306f2c44d266255318b3775bacfec42a77ca83e998f2
-HIERO_ENVIRONMENT_TYPE=local
+HIERO_ENVIRONMENT_TYPE=custom
+HIERO_CONSENSUS_NODES=127.0.0.1:50211,127.0.0.1:51211
+HIERO_CONSENSUS_NODE_ACCOUNT_IDS=0.0.3,0.0.4
+HIERO_MIRROR_NODES=127.0.0.1:5600
 ```
 
-## Contribute
+> **Note:** Some tests that trigger address book updates require `/etc/hosts` entries for Kubernetes DNS names. See [Tests/README.md](./Tests/README.md#kubernetes-dns-configuration-required-for-node-update-tests) for details.
 
-- To contribute, please refer to the **[Hiero-Ledger's contribution guidelines](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md)**
+---
 
-## Help/Community
+## Contributing
 
-- Join our [community discussions](https://discord.lfdecentralizedtrust.org/) on discord.
+We welcome contributions from the community! Please refer to the [Hiero contribution guidelines](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md) before getting started.
 
-## About Users and Maintainers
+---
 
-- Users and Maintainers guidelies are located in **[Hiero-Ledger's roles and groups guidelines](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers).**
+## Community
+
+- **Discord**: Join the conversation on [LF Decentralized Trust Discord](https://discord.lfdecentralizedtrust.org/)
+- **Governance**: Learn about roles and responsibilities in the [Hiero governance documentation](https://github.com/hiero-ledger/governance/blob/main/roles-and-groups.md#maintainers)
+
+---
 
 ## License
 
-- Hiero's source code is available under the **Apache License, Version 2.0 (Apache-2.0)**
+This project is licensed under the **Apache License, Version 2.0**. See [LICENSE](LICENSE) for details.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 ## Release
 1. Create a new git branch: `release/vX.Y.Z`.
 >- Follows [semver 2.0](https://semver.org/spec/v2.0.0.html)
-2. Run all tests against [hiero-local-node](https://github.com/hiero-ledger/hiero-local-node). Stop local-node once the tests are completed.
+2. Run all tests against [Hiero Solo](https://github.com/hiero-ledger/solo). Stop Solo once the tests are completed.
 >- `swift test`
 3. Create a new tag.
 >- `git push -a <version> -m <version>`

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -97,19 +97,22 @@ HIERO_OPERATOR_KEY=302e020100300506032b657004220420...
 HIERO_ENVIRONMENT_TYPE=testnet
 ```
 
-### Local Node Setup
+### Solo Setup
 
-For testing against [hiero-local-node](https://github.com/hiero-ledger/hiero-local-node):
+For local development and testing, we recommend using [Hiero Solo](https://github.com/hiero-ledger/solo). Solo provides a lightweight, local Hiero network running in Kubernetes.
 
 ```bash
 HIERO_OPERATOR_ID=0.0.2
 HIERO_OPERATOR_KEY=3030020100300706052b8104000a042204205bc004059ffa2943965d306f2c44d266255318b3775bacfec42a77ca83e998f2
-HIERO_ENVIRONMENT_TYPE=local
+HIERO_ENVIRONMENT_TYPE=custom
+HIERO_CONSENSUS_NODES=127.0.0.1:50211,127.0.0.1:51211
+HIERO_CONSENSUS_NODE_ACCOUNT_IDS=0.0.3,0.0.4
+HIERO_MIRROR_NODES=127.0.0.1:5600
 ```
 
 #### Kubernetes DNS Configuration (Required for Node Update Tests)
 
-When running against a local Kubernetes-based Hedera network (e.g., solo), some tests that trigger address book updates (like `NodeUpdateTransactionIntegrationTests`) require `/etc/hosts` entries for the Kubernetes internal DNS names.
+When running against Solo, some tests that trigger address book updates (like `NodeUpdateTransactionIntegrationTests`) require `/etc/hosts` entries for the Kubernetes internal DNS names.
 
 Add the following to your `/etc/hosts` file:
 
@@ -143,9 +146,9 @@ HIERO_PROFILE=local
 
 | Profile | Description |
 |---------|-------------|
-| `local` | Local development with local node (default) |
+| `local` | Local development with Solo (default) |
 | `ciUnit` | CI unit tests - unit environment |
-| `ciIntegration` | CI integration tests - local environment, verbose logging |
+| `ciIntegration` | CI integration tests - Solo environment, verbose logging |
 | `development` | Development against remote networks (testnet) |
 
 ### Feature Flags


### PR DESCRIPTION
## Summary

This PR refreshes the README and related documentation files with improved formatting, accurate information, and updated references. The main changes modernize the documentation to reflect current project ownership (removing LaunchBadge, which is no longer a maintainer), update testing references from the deprecated `hiero-local-node` to [Hiero Solo](https://github.com/hiero-ledger/solo), and add missing maintainer contact information.

**Key Changes:**
- Remove LaunchBadge from maintainer attribution
- Replace all `hiero-local-node` references with Hiero Solo
- Fix incorrect GitHub URL (`hiero-project` → `hiero-ledger`)
- Improve README organization with table of contents and cleaner formatting
- Simplify examples section to avoid maintenance burden
- Add contact information for maintainers

---

## Changes

### 📝 README Restructuring

Complete reorganization of the README for better readability and maintainability:

- Added **Table of Contents** with anchor links for easy navigation
- Converted requirements and tooling sections to **table format**
- Added horizontal rules between sections for visual clarity
- Improved section hierarchy and headings
- Renamed sections for clarity (`Usage` → `Quick Start`, `Contribute` → `Contributing`, etc.)

### 🏷️ Maintainer Attribution Update

Updated the maintainer line to reflect current project ownership:

| Before | After |
|--------|-------|
| "Maintained with ❤️ by LaunchBadge, Hashgraph, and the Hiero community" | "Maintained with ❤️ by Hashgraph and the Hiero community" |

### 👥 Maintainer Contact Information

Added Discord IDs and email addresses for maintainers in `MAINTAINERS.md`:

| Maintainer | Discord ID | Email |
|------------|------------|-------|
| Rob Walworth | robert.walworth | robert.walworth@swirldslabs.com |
| Simi Hunjan | simihunjan | simi@swirldslabs.com |

### 🔗 URL Corrections

Fixed incorrect GitHub repository URL in the installation section:

| Before | After |
|--------|-------|
| `https://github.com/hiero-project/hiero-sdk-swift.git` | `https://github.com/hiero-ledger/hiero-sdk-swift.git` |

### 🧪 Testing Environment Updates

Replaced all references to `hiero-local-node` with Hiero Solo across documentation:

- **README.md**: Updated testing section with Solo configuration
- **Tests/README.md**: Updated "Local Node Setup" to "Solo Setup" with correct environment variables
- **RELEASE.md**: Updated release testing instructions

**Environment type change:** `HIERO_ENVIRONMENT_TYPE=local` → `HIERO_ENVIRONMENT_TYPE=custom`

**New Solo Configuration:**
```bash
HIERO_OPERATOR_ID=0.0.2
HIERO_OPERATOR_KEY=3030020100300706052b8104000a042204205bc004059ffa2943965d306f2c44d266255318b3775bacfec42a77ca83e998f2
HIERO_ENVIRONMENT_TYPE=custom
HIERO_CONSENSUS_NODES=127.0.0.1:50211,127.0.0.1:51211
HIERO_CONSENSUS_NODE_ACCOUNT_IDS=0.0.3,0.0.4
HIERO_MIRROR_NODES=127.0.0.1:5600
```

### ⚙️ Required Tooling Corrections

Updated the required tooling section to accurately reflect dependencies:

| Before | After |
|--------|-------|
| `protoc` (no link) | `protoc` with link to Protocol Buffers repo |
| `protoc-gen-swift` | `protoc-gen-swift` ✓ |
| `protoc-gen-grpc-swift` | `protoc-gen-grpc-swift` ✓ |
| `task` | `task` ✓ |
| OpenSSL 3.4 | ❌ Removed (not required) |
| — | `python3` ✅ Added (required for proto generation) |

### 📁 Examples Section Simplification

Simplified the examples section to reference the directory rather than listing all examples:

| Before | After |
|--------|-------|
| Detailed instructions with `$` prompt prefixes | Clean command examples without shell prompts |
| Separate "Examples" and running sections | Combined into single concise section |

### 🧹 Additional Cleanup

- Updated license badge text: `license-apache2` → `license-Apache%202.0`
- Improved SDK description: "The SDK for interacting with a Hiero based network" → "The Swift SDK for interacting with Hiero-based networks"
- Added link to Hiero.org in the description
- Improved code example variable naming: `ab` → `balance`, `ab.balance` → `balance.hbars`
- Updated test profile descriptions in Tests/README.md to reference Solo

---

## Testing

**Test Plan:**
- [x] Verify README renders correctly with table of contents
- [x] Verify all internal anchor links work
- [x] Verify external links point to correct repositories
- [x] Verify Solo configuration matches CI workflow values

---

## Files Changed Summary

| File | Changes |
|------|---------|
| `README.md` | Complete restructure: TOC, tables, Solo references, URL fix, maintainer update |
| `MAINTAINERS.md` | Added Discord IDs and email addresses for maintainers |
| `Tests/README.md` | Solo references, environment config, profile descriptions |
| `RELEASE.md` | Solo reference for release testing |

---

## Breaking Changes

**None.** This PR only contains documentation changes with no impact on SDK functionality or public APIs.

---

## Benefits

1. **Accurate information** — Reflects current maintainership and correct repository URLs
2. **Modern testing guidance** — Points users to Solo instead of deprecated local-node
3. **Easier navigation** — Table of contents helps users find information quickly
4. **Reduced maintenance** — Examples section no longer requires updates when examples change
5. **Cleaner formatting** — Tables and consistent structure improve readability
6. **Better discoverability** — Maintainer contact info helps community reach out
