### PR TITLE
chore: Bump version to v0.46.0

### DIFF
--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 public enum VersionInfo {
-    public static let version = "v0.45.0"
+    public static let version = "v0.46.0"
 }


### PR DESCRIPTION
## Summary

This PR updates the SDK version from `v0.45.0` to `v0.46.0` in preparation for the next release. The version string is used in the gRPC user-agent header to identify SDK requests to the network.

**Key Changes:**
- Update `VersionInfo.version` constant to `v0.46.0`

---

## Changes

### Version Update

Updated the static version constant in `Version.swift` from `v0.45.0` to `v0.46.0`.

This version string is referenced in `Execute.swift` to set the `x-user-agent` header on all gRPC requests:

```swift
var options = CallOptions(customMetadata: ["x-user-agent": "hiero-sdk-swift/" + VersionInfo.version])
```

---

## Testing

**Test Plan:**
- [x] Verify project builds successfully
- [x] Confirm version constant is correctly updated

---

## Files Changed Summary

| Category | Files |
|----------|-------|
| Source | `Sources/Hiero/Version.swift` |

---

## Breaking Changes

**None.** This is a version bump only with no API or behavioral changes.
