### PR TITLE
chore: Update Version for v0.47.0 Release

### DIFF
--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 public enum VersionInfo {
-    public static let version = "v0.46.0"
+    public static let version = "v0.47.0"
 }


### PR DESCRIPTION
## Summary

This PR updates the SDK version from `v0.46.0` to `v0.47.0` in preparation for the next release. This is a standard version bump to mark the release milestone.

---

## Changes

### Version Update

- Updated `VersionInfo.version` constant from `"v0.46.0"` to `"v0.47.0"`

| Before | After |
|--------|-------|
| `v0.46.0` | `v0.47.0` |

**Files Changed:**
- `Sources/Hiero/Version.swift`

---

## Testing

```bash
swift build  # ✅ Project builds successfully
```

**Test Plan:**
- [x] Verify project compiles with updated version
- [x] Verify version string is correctly set

---

## Files Changed Summary

| Category | Files | Notes |
|----------|-------|-------|
| SDK Source | `Sources/Hiero/Version.swift` | Version bump |

**Summary:**
- **1 file changed**
- **1 insertion, 1 deletion**

---

## Breaking Changes

**None.** This is a version metadata update only with no functional changes to the SDK.
