### PR TITLE
fix: remove noisy 'Resource cleanup is disabled' message

### DIFF
--- a/Tests/HieroTestSupport/Helpers/ResourceManager.swift
+++ b/Tests/HieroTestSupport/Helpers/ResourceManager.swift
@@ -278,7 +278,6 @@ public actor ResourceManager {
         if !cleanupPolicy.cleanupAccounts && !cleanupPolicy.cleanupTokens && !cleanupPolicy.cleanupFiles
             && !cleanupPolicy.cleanupTopics && !cleanupPolicy.cleanupContracts
         {
-            print("Resource cleanup is disabled - skipping")
             return
         }
 


### PR DESCRIPTION
## Summary
Closes #505

Removed the print statement that outputs `Resource cleanup is disabled - skipping` for every test when cleanup is disabled.

## Problem
- The message appeared hundreds of times during test runs
- Cluttered test output and CI logs
- Made it harder to spot real warnings

## Solution
Removed the single print statement on line 281 of `ResourceManager.swift`.

## Changes
- Removed: `print("Resource cleanup is disabled - skipping")`
- No other changes to logic or behavior