### PR TITLE
chore: Update mirror node version to v0.147.0

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           soloVersion: v0.54.0
           installMirrorNode: true
-          mirrorNodeVersion: v0.146.0
+          mirrorNodeVersion: v0.147.0
           hieroVersion: v0.69.1
           dualMode: true
       


### PR DESCRIPTION
## Summary

This PR updates the mirror node version used in CI integration tests from `v0.146.0` to `v0.147.0`.

## Changes

### CI Configuration

- Updated `mirrorNodeVersion` from `v0.146.0` to `v0.147.0` in the Hiero Solo Action configuration

**Files Changed:**
- `.github/workflows/swift-ci.yml`

## Testing

```bash
swift test --filter HieroIntegrationTests  # Verify tests pass with new mirror node version
```

**Test Plan:**
- [ ] CI pipeline runs successfully with the updated mirror node version
- [ ] Integration tests pass against the new mirror node

## Files Changed Summary

| Category | Files |
|----------|-------|
| CI/CD | `.github/workflows/swift-ci.yml` |

## Breaking Changes

**None.** This is a routine version bump for the mirror node used in CI testing.
