### PR TITLE
docs: Add documentation comments to TransactionHash.swift

### DIFF
--- a/Sources/Hiero/Transaction/TransactionHash.swift
+++ b/Sources/Hiero/Transaction/TransactionHash.swift
@@ -12,8 +12,8 @@ import Foundation
 /// ## Example
 /// ```swift
 /// let transaction = TransferTransaction()
-///     .addHbarTransfer(sender, .init(amount: -100))
-///     .addHbarTransfer(receiver, .init(amount: 100))
+///     .hbarTransfer(sender, Hbar.fromTinybars(-100))
+///     .hbarTransfer(receiver, Hbar.fromTinybars(100))
 ///
 /// let response = try await transaction.execute(client)
 /// let hash = response.transactionHash


### PR DESCRIPTION
## Summary

Implements #538

Added comprehensive Swift documentation comments (`///`) to the `TransactionHash` struct and its public members to improve readability and maintainability.

## Changes

Added documentation to:
- **The struct itself**: Explains what a transaction hash is (SHA-384 hash), its purposes (tracking transactions, referencing in queries, verification), and includes a code example
- **`data` property**: Documents that it holds the raw 48-byte (384-bit) hash value
- **`description` property**: Explains it returns a lowercase hex-encoded string (96 characters)

## Checklist

- [x] Changes are limited to documentation comments only
- [x] No SDK behavior or public API changes
- [x] Existing code still compiles
- [x] Commit is signed off (`-s`)

## Notes

I wasn't able to GPG sign (`-S`) the commit as I don't have GPG keys configured on this machine. If GPG signing is strictly required, please let me know and I can set that up.

---

This is my first contribution to the Hiero SDK. Thanks for the welcoming issue documentation!