### PR TITLE
ci: upgrade solo to v0.55.0

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@fbca3e7a99ce9aa8a250563a81187abe115e0dad # v0.16.0
         with:
-          soloVersion: v0.54.0
+          soloVersion: v0.55.0
           installMirrorNode: true
           mirrorNodeVersion: v0.147.0
           hieroVersion: v0.70.0


### PR DESCRIPTION
## Summary

This PR upgrades Hiero Solo from v0.54.0 to v0.55.0 in the CI workflow to ensure integration tests run against the latest Solo release.

## Changes

### CI Configuration

- Updated `soloVersion` from `v0.54.0` to `v0.55.0` in `.github/workflows/swift-ci.yml`

**Files Changed:**
- `.github/workflows/swift-ci.yml`

## Testing

- [ ] CI pipeline runs successfully with the new Solo version
- [ ] Integration tests pass against Solo v0.55.0

## Files Changed Summary

| Category | Files |
|----------|-------|
| CI | `.github/workflows/swift-ci.yml` |

**Total:** 1 file changed, 1 insertion(+), 1 deletion(-)

## Breaking Changes

**None.** This is a CI dependency version bump with no impact on SDK source code or public APIs.