### PR TITLE
chore: upgrade Solo to v0.56.0

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@fbca3e7a99ce9aa8a250563a81187abe115e0dad # v0.16.0
         with:
-          soloVersion: v0.55.0
+          soloVersion: v0.56.0
           installMirrorNode: true
           mirrorNodeVersion: v0.147.0
           hieroVersion: v0.71.0


### PR DESCRIPTION
## Summary

This PR upgrades the Hiero Solo version used in Swift CI from v0.55.0 to v0.56.0. Integration tests continue to run against the same consensus node (v0.71.0) and mirror node (v0.147.0); only the Solo orchestration layer is updated to pick up the latest solo release.

**Key Changes:**
- Bump `soloVersion` in the Swift CI workflow from `v0.55.0` to `v0.56.0`

## Changes

### CI / Workflow

- **`.github/workflows/swift-ci.yml`**: Set `soloVersion` from `v0.55.0` to `v0.56.0` in the `hiero-solo-action` step so the local network and integration test environment use Solo v0.56.0.

**Files Changed:**
- `.github/workflows/swift-ci.yml`

## Testing

```bash
# CI runs integration tests against Solo v0.56.0
# (Swift CI job: Prepare Hiero Solo → Run integration tests)
swift test --filter HieroIntegrationTests   # ✅ (in CI)
```

**Test Plan:**
- [x] Swift CI workflow updated to use `soloVersion: v0.56.0`
- [x] No SDK source or API changes; verification is via CI integration test run

## Files Changed Summary

| Category | Files |
|----------|-------|
| CI       | `.github/workflows/swift-ci.yml` |

**Counts:** 1 file changed, 1 insertion, 1 deletion.

## Breaking Changes

**None.** This is a CI-only change. Solo version does not affect SDK API or runtime behavior.
