### PR TITLE
add caseIterable conformance and unit test file for request type #554

### DIFF
--- a/Sources/Hiero/FeeSchedule/RequestType.swift
+++ b/Sources/Hiero/FeeSchedule/RequestType.swift
@@ -6,7 +6,7 @@ import HieroProtobufs
 // swiftlint:disable file_length
 
 /// The functionality provided by Hiero.
-public enum RequestType {
+public enum RequestType: CaseIterable {
     /// Transfer from one account to another.
     case cryptoTransfer
 

--- a/Tests/HieroUnitTests/RequestTypeUnitTests.swift
+++ b/Tests/HieroUnitTests/RequestTypeUnitTests.swift
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import HieroTestSupport
+import XCTest
+
+@testable import Hiero
+
+internal final class RequestTypeUnitTests: HieroUnitTestCase {
+    internal func test_AllCases_ProtobufRoundtrip() throws {
+        for original in RequestType.allCases {
+            let proto = original.toProtobuf()
+            let roundtripped = try RequestType(protobuf: proto)
+            XCTAssertEqual(roundtripped, original, "Protobuf roundtrip failed for: \(original)")
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
Add unit tests for `RequestType` enum to ensure all cases roundtrip through correctly.

* Add `CaseIterable` conformance to `RequestType` enum
* Create `RequestTypeUnitTests.swift` with test file

**Related issue(s)**:

Fixes #554 

**Notes for reviewer**:
The `RequestType` enum has 70+ cases representing all Hiero functionality types. Previously, only `nil` values were tested in `FeeScheduleUnitTests.swift`. This test ensures every case converts to protobuf and back without data loss.

Using `CaseIterable` means the test automatically adapts when new request types are added.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

---
## Tests:

## Test 1: Unit Testing using:
```sh
 swift test --filter RequestTypeUnitTests
```
## Result:
<img width="737" height="244" alt="selected-test" src="https://github.com/user-attachments/assets/36ef9034-250a-4d39-aec3-b183bebf2ece" />

---

## Test 2: Integration testing using:

```sh
 swift test
```
## Result:
<img width="794" height="287" alt="full test" src="https://github.com/user-attachments/assets/e59709ed-9fba-443c-86a5-bfc46f6b642b" />

---
