### PR TITLE
Fix incorrect class in AccountUpdateTransaction.swift

### DIFF
--- a/Sources/Hiero/Account/AccountUpdateTransaction.swift
+++ b/Sources/Hiero/Account/AccountUpdateTransaction.swift
@@ -13,7 +13,7 @@ import SwiftProtobuf
 /// signed by both the old key (from before the change) and the new key.
 ///
 public final class AccountUpdateTransaction: Transaction {
-    /// Create a new `AccountCreateTransaction` ready for configuration.
+    /// Create a new `AccountUpdateTransaction` ready for configuration.
     public override init() {
         super.init()
     }


### PR DESCRIPTION
**Description**:
This PR fixes an incorrect class name in the comment in the AccountUpdateTransaction.swift file

**Related issue(s)**:

Fixes #570 
