### PR TITLE
chore(ci): update hiero-solo version to v0.59.1

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@fbca3e7a99ce9aa8a250563a81187abe115e0dad # v0.16.0
         with:
-          soloVersion: v0.58.0
+          soloVersion: v0.59.1
           installMirrorNode: true
           mirrorNodeVersion: v0.147.0
           hieroVersion: v0.71.0


### PR DESCRIPTION
**Description**:
Update the Hiero Solo version used in CI from `v0.58.0` to `v0.59.1`.

**Related issue(s)**:

Fixes #581

**Notes for reviewer**:
- CI will automatically run and validate the new Solo version.

**Checklist**

- [X] Tested (unit, integration, etc.)
