### PR TITLE
chore: release v0.49.0

### DIFF
--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -3,5 +3,5 @@
 /// Contains SDK version information.
 public enum VersionInfo {
     /// The current version of the Hiero SDK.
-    public static let version = "v0.48.0-dev"
+    public static let version = "v0.49.0"
 }


### PR DESCRIPTION
## Summary

Bumps the SDK version string from `v0.48.0-dev` to `v0.49.0` to cut the v0.49.0 release.

## Changes

- `Sources/Hiero/Version.swift`: `v0.48.0-dev` → `v0.49.0`

## Files Changed Summary

| File | Change |
|------|--------|
| `Sources/Hiero/Version.swift` | Version bump `v0.48.0-dev` → `v0.49.0` |

## Breaking Changes

**None.**
