### PR TITLE
fix: handle gRPC connection pool errors and update CI solo versions

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.67.0
+          soloVersion: v0.68.0
           installMirrorNode: true
           mirrorNodeVersion: v0.151.0
           hieroVersion: v0.72.0

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -108,11 +108,11 @@ jobs:
 
       - name: Prepare Hiero Solo
         id: solo
-        uses: hiero-ledger/hiero-solo-action@fbca3e7a99ce9aa8a250563a81187abe115e0dad # v0.16.0
+        uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 
         with:
-          soloVersion: v0.59.1
+          soloVersion: v0.67.0
           installMirrorNode: true
-          mirrorNodeVersion: v0.149.0
+          mirrorNodeVersion: v0.151.0
           hieroVersion: v0.72.0
           dualMode: true
       

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.63.0
+          soloVersion: v0.69.0
           installMirrorNode: true
           mirrorNodeVersion: v0.152.0
           hieroVersion: v0.72.0

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.64.1
+          soloVersion: v0.64.0
           installMirrorNode: true
           mirrorNodeVersion: v0.152.0
           hieroVersion: v0.72.0

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,9 +110,9 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.68.0
+          soloVersion: v0.69.0
           installMirrorNode: true
-          mirrorNodeVersion: v0.151.0
+          mirrorNodeVersion: v0.152.0
           hieroVersion: v0.72.0
           dualMode: true
       

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.69.0
+          soloVersion: v0.59.1
           installMirrorNode: true
           mirrorNodeVersion: v0.152.0
           hieroVersion: v0.72.0

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.64.0
+          soloVersion: v0.63.0
           installMirrorNode: true
           mirrorNodeVersion: v0.152.0
           hieroVersion: v0.72.0

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -110,7 +110,7 @@ jobs:
         id: solo
         uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
-          soloVersion: v0.59.1
+          soloVersion: v0.64.1
           installMirrorNode: true
           mirrorNodeVersion: v0.152.0
           hieroVersion: v0.72.0

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Prepare Hiero Solo
         id: solo
-        uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 
+        uses: hiero-ledger/hiero-solo-action@692b186bd2e4c8d46b9deb1c067dc6ddcf0abcd7 # v0.18.0
         with:
           soloVersion: v0.67.0
           installMirrorNode: true

--- a/Sources/Hiero/Execute.swift
+++ b/Sources/Hiero/Execute.swift
@@ -495,6 +495,8 @@ private func executeOnNode<E: Execute>(
         response = try await executable.execute(channel, request, ctx.grpcDeadline)
     } catch let error as GRPCStatus {
         return try handleGrpcError(error, nodeIndex: nodeIndex, ctx: ctx)
+    } catch let error as GRPCConnectionPoolError {
+        return handleConnectionPoolError(error, nodeIndex: nodeIndex, ctx: ctx)
     }
 
     ctx.network.markNodeHealthy(at: nodeIndex)
@@ -547,6 +549,31 @@ private func handleGrpcError<Response>(
     default:
         throw hError
     }
+}
+
+/// Handles gRPC connection pool errors and determines retry strategy.
+///
+/// The gRPC connection pool throws `GRPCConnectionPoolError` (not `GRPCStatus`) when it
+/// cannot acquire an HTTP/2 stream before the call deadline — for example, when the node is
+/// temporarily unavailable or the pool has no open connections. This is always treated as a
+/// transient failure: the node is marked unhealthy and the request is retried immediately.
+///
+/// - Parameters:
+///   - error: The connection pool error
+///   - nodeIndex: Index of the node that returned the error
+///   - ctx: Execution context
+/// - Returns: Execution result for retry decision
+private func handleConnectionPoolError<Response>(
+    _ error: GRPCConnectionPoolError,
+    nodeIndex: Int,
+    ctx: ExecuteContext
+) -> ExecutionResult<Response> {
+    let hError = HError(
+        kind: .grpcStatus(status: Int32(GRPCStatus.Code.deadlineExceeded.rawValue)),
+        description: error.description
+    )
+    ctx.network.markNodeUnhealthy(at: nodeIndex)
+    return .retryImmediately(hError)
 }
 
 /// Handles Hedera pre-check status codes and determines retry strategy.


### PR DESCRIPTION
## Summary

This PR fixes a bug in the SDK's gRPC error handling that caused integration test failures when running against newer versions of Hiero Solo (v0.64+), and updates the CI workflow to use the latest Solo component versions.

**Key Changes:**
- Catch `GRPCConnectionPoolError` in `executeOnNode` so connection pool failures enter retry logic instead of propagating immediately
- Upgrade CI: hiero-solo-action v0.16.0 → v0.18.0, Solo v0.59.1 → v0.69.0, Mirror Node v0.149.0 → v0.152.0

---

## Motivation

Solo v0.64 parallelised its startup sequence (removing sequential sleep timers) and changed its node initialisation accounts. On the shared CI runner - which hosts 2 consensus nodes, a mirror node, and a KIND cluster concurrently - this caused the consensus node JVMs to still be mid-warmup when integration tests began.

G1GC is a stop-the-world collector. When a JVM GC pause fires, **all** server-side threads halt, including the gRPC-Java/Netty network threads. From the client's perspective the node disappears: HTTP/2 keepalive pings go unanswered, the client-side NIO event loop drops the connection, and subsequent requests queue in the gRPC connection pool waiting for a new connection. With a 2-node network that requires full quorum (2/2 nodes), either node going silent stalls consensus.

The existing `executeOnNode` catch only handled `GRPCStatus`:

```swift
} catch let error as GRPCStatus {
    return try handleGrpcError(error, nodeIndex: nodeIndex, ctx: ctx)
}
// GRPCConnectionPoolError escapes here - no retry, propagates directly to caller
```

When the connection pool cannot acquire an HTTP/2 stream before the 10-second call deadline, it throws `GRPCConnectionPoolError.deadlineExceeded` - a **separate type** from `GRPCStatus` in grpc-swift. This error bypassed the catch entirely, skipping all retry logic and propagating raw to test functions. The observable symptom was tests failing with exactly 10-second timeouts and the string `"deadlineExceeded"` (the inner enum case name) rather than an `HError`.

CI failure pattern (all exactly 10 seconds, back-to-back):
```
AccountUpdateTransactionIntegrationTests.test_CannotUpdateWithHookAlreadyInUse : threw error "deadlineExceeded"  (10.008s)
AccountUpdateTransactionIntegrationTests.test_CannotUpdateWithMultipleOfSameHook : threw error "deadlineExceeded" (10.004s)
AccountUpdateTransactionIntegrationTests.test_MissingAccountIdFails : assertThrowsHErrorAsync failed: did not throw a HError: deadlineExceeded (10.003s)
FileInfoQueryIntegrationTests.test_QueryCostBigMax : threw error "deadlineExceeded"  (10.008s)
```

---

## Changes

### 1. Catch `GRPCConnectionPoolError` in `executeOnNode`

**File:** `Sources/Hiero/Execute.swift`

Added a second catch clause immediately after the `GRPCStatus` clause, and a dedicated
`handleConnectionPoolError` helper that mirrors the transient-failure path in `handleGrpcError`:

```swift
} catch let error as GRPCStatus {
    return try handleGrpcError(error, nodeIndex: nodeIndex, ctx: ctx)
} catch let error as GRPCConnectionPoolError {
    return handleConnectionPoolError(error, nodeIndex: nodeIndex, ctx: ctx)
}
```

`handleConnectionPoolError` marks the node unhealthy and returns `.retryImmediately`, which feeds the existing retry machinery: the SDK tries the other node, and if both are unhealthy backs off exponentially up to the 2-minute `requestTimeout` / 10-attempt `maxAttempts` budget. The error is wrapped as `HError.grpcStatus(status: deadlineExceeded)` so assertion helpers (`assertReceiptStatus`, `assertPrecheckStatus`, etc.) receive a proper `HError` rather than an opaque `Error`.

### 2. CI workflow - component version updates

**File:** `.github/workflows/swift-ci.yml`

| Component | Before | After |
|-----------|--------|-------|
| `hiero-solo-action` | `v0.16.0` (`fbca3e7...`) | `v0.18.0` (`692b186...`) |
| `soloVersion` | `v0.59.1` | `v0.69.0` |
| `mirrorNodeVersion` | `v0.149.0` | `v0.152.0` |
| `hieroVersion` | `v0.72.0` | `v0.72.0` (unchanged) |

Solo v0.69.0 includes upstream fixes for the parallel startup race conditions introduced in v0.64 (solo PRs #3817, #3807), making the CI environment stable enough for the remaining GC pause windows to be covered by the SDK's retry logic.

---

## Technical Details

### Why `GRPCConnectionPoolError` Is a Distinct Type

In grpc-swift, `GRPCConnectionPoolError` implements `GRPCStatusTransformable` (it can produce a `GRPCStatus` on demand) but is not itself a `GRPCStatus`. The connection pool throws it when a waiter times out waiting for an HTTP/2 stream:

```swift
// grpc-swift ConnectionPool.swift
waiter.scheduleTimeout(on: self.eventLoop) {
    waiter.fail(GRPCConnectionPoolError.deadlineExceeded(connectionError: self._mostRecentError))
    ...
}
```

`GRPCConnectionPoolError.Code.description` returns the raw Swift enum case name (`"deadlineExceeded"`, camelCase), which is what appeared in test output - confirming the error type.

### Why Only Some Tests Failed

The JVM GC pause is timer-triggered by heap pressure, not by test count. In the CI run analysed, the pause hit at approximately t+45s into test execution (coinciding with `test_CannotUpdateWithHookAlreadyInUse`). Tests running before that window used already-established connections and passed normally. Tests after the pause completed (t+75s onward) also passed, albeit slowly (~9–24 seconds) as the JVM recovered. A second shorter pause at t+188s took out one `FileInfoQuery` test.

### Retry Behaviour After This Fix

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| Connection pool timeout on node A | Propagates immediately as raw non-`HError` | Node A marked unhealthy, retries node B |
| Both nodes connection pool timeout | Propagates immediately | Retries with exponential backoff until `requestTimeout` (2 min) |
| Error visible to test assertion helpers | No (`catch error`, not `catch HError`) | Yes (`HError.grpcStatus`) |

---

## Testing

The most recent CI run on this branch (`ci-update-solo-action-component-versions`) passes with Solo v0.69.0 across all Swift matrix versions:

```
swift test --filter HieroIntegrationTests   # ✅ all tests pass (Swift 5.9, 5.10, 6.0, 6.1, 6.2)
```

**Test plan:**
- [x] Confirm `Build complete` with no compiler errors or warnings on `swift build`
- [x] Confirm latest CI run succeeds with updated Solo versions
- [x] Confirm error path: `GRPCConnectionPoolError` is now caught and does not propagate to callers

---

## Files Changed Summary

| Category | File | Change |
|----------|------|--------|
| SDK source | `Sources/Hiero/Execute.swift` | Add `GRPCConnectionPoolError` catch + `handleConnectionPoolError` |
| CI workflow | `.github/workflows/swift-ci.yml` | Update Solo action and component versions |

---

## Breaking Changes

**None.** The change is purely additive error handling in a private function. All public APIs are unchanged. Tests that previously failed with a raw `"deadlineExceeded"` error will now either succeed (if a healthy node is available within the retry budget) or fail with `HError.timedOut` (a proper `HError`).
