### PR TITLE
fix: replace fatalError with thrown error in signWithOperator

### DIFF
--- a/Sources/Hiero/Transaction.swift
+++ b/Sources/Hiero/Transaction.swift
@@ -317,7 +317,7 @@ public class Transaction: ValidateChecksums {
     @discardableResult
     public final func signWithOperator(_ client: Client) throws -> Self {
         guard let `operator` = client.operator else {
-            fatalError("todo: error here (Client had no operator)")
+            throw HError.noPayerAccountOrTransactionId
         }
 
         try freezeWith(client)


### PR DESCRIPTION
## Summary

This PR fixes a crash in `signWithOperator(_:)` that occurred when the client had no operator configured. Instead of calling `fatalError`, which unconditionally terminates the process, the method now throws `HError.noPayerAccountOrTransactionId`, giving callers the opportunity to handle the error gracefully.

**Key Changes:**
- Replace `fatalError("todo: error here (Client had no operator)")` with `throw HError.noPayerAccountOrTransactionId` in `Transaction.signWithOperator(_:)`

---

## Changes

### Replace `fatalError` with a Thrown Error

**Problem:** `Transaction.signWithOperator(_:)` called `fatalError` when the client had no operator, crashing the entire process instead of surfacing a recoverable error.

**Discovery:** This bug was surfaced by the Swift SDK TCK compatibility workflow ([hiero-sdk-tck#636](https://github.com/hiero-ledger/hiero-sdk-tck/pull/636)). The `HieroTCK` server runs inside a Vapor process — when a test triggered `signWithOperator` on a client with no operator set, the `fatalError` killed the entire server process mid-run, causing all 317 subsequent TCK tests to fail with `ECONNREFUSED` on port 8544.

**Root Cause:** A `// TODO` stub was left in place that used `fatalError` as a placeholder.

**Fix:** The method already throws (its signature is `throws`), and `HError.noPayerAccountOrTransactionId` is the established error for this exact condition — already used in three other locations in the codebase ([Transaction.swift:786](Sources/Hiero/Transaction.swift), [Transaction.swift:901](Sources/Hiero/Transaction.swift), [ChunkedTransaction.swift:217](Sources/Hiero/ChunkedTransaction.swift)). Replacing the `fatalError` with this throw makes the behavior consistent and recoverable.

**Files Changed:**
- [Sources/Hiero/Transaction.swift](Sources/Hiero/Transaction.swift) — line 320

---

## Testing

**Test Plan:**
- [x] Verify the project builds successfully
- [x] Verify that calling `signWithOperator` on a client without an operator now throws instead of crashing
- [x] Confirm existing tests continue to pass

---

## Files Changed Summary

| Category | Files |
|----------|-------|
| Source | [`Sources/Hiero/Transaction.swift`](Sources/Hiero/Transaction.swift) |

---

## Breaking Changes

**None.** The method signature was already declared `throws`. Callers that previously crashed (due to `fatalError`) will now receive a thrown `HError.noPayerAccountOrTransactionId` error, which is strictly an improvement.
