### PR TITLE
chore: release v0.50.0

### DIFF
--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -3,5 +3,5 @@
 /// Contains SDK version information.
 public enum VersionInfo {
     /// The current version of the Hiero SDK.
-    public static let version = "v0.49.0"
+    public static let version = "v0.50.0"
 }


### PR DESCRIPTION
## Summary

Bumps `VersionInfo.version` from `v0.49.0` to `v0.50.0`.

## Files Changed Summary

| File | Change |
|------|--------|
| `Sources/Hiero/Version.swift` | `v0.49.0` → `v0.50.0` |

## Breaking Changes

**None.**
