### PR TITLE
fix: strip leading v prefix from version string in Taskfile.yml

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,7 +11,7 @@ tasks:
                 /// Contains SDK version information.
                 public enum VersionInfo {
                     /// The current version of the Hiero SDK.
-                    public static let version = \"$(git describe --tags $(git rev-list --tags --max-count=1))-dev\"
+                    public static let version = \"$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')-dev\"
                 }" > Sources/Hiero/Version.swift
             - swift build
 
@@ -51,7 +51,7 @@ tasks:
                 /// Contains SDK version information.
                 public enum VersionInfo {
                     /// The current version of the Hiero SDK.
-                    public static let version = \"$(git describe --tags)\"
+                    public static let version = \"$(git describe --tags | sed 's/^v//')\"
                 }" > Sources/Hiero/Version.swift
             - swift build -c release
 


### PR DESCRIPTION
**Description**:

The SDK was sending the x-user-agent gRPC header as hiero-sdk-swift/v0.50.0. The consensus node's semver parser does not accept a leading v, causing the SDK version to be recorded as Unknown. This PR fixes that by stripping the v prefix before it is written into Version.swift.

Fixes: #602 

Changes:
Taskfile.yml — lines 14 and 54