### PR TITLE
feat: add setOperatorWith() method to Client

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -516,9 +516,9 @@ public final class Client: Sendable {
         _ publicKey: PublicKey,
         _ signer: @Sendable @escaping (Data) -> Data
     ) -> Self {
-        _operator.withLockedValue {
-            $0 = Operator(accountId: accountId, signer: Signer(publicKey, signer))
-        }
+        _operator.withLockedValue { op in
+            op = Operator(accountId: accountId, signer: Signer(publicKey, signer))
+       }
 
         return self
     }

--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -500,6 +500,29 @@ public final class Client: Sendable {
         return self
     }
 
+    /// Sets the operator using a custom signer.
+    ///
+    /// This allows integration with HSMs, remote signing services, or other
+    /// systems that don't expose raw private keys.
+    ///
+    /// - Parameters:
+    ///   - accountId: Account ID to use as operator
+    ///   - publicKey: Public key corresponding to the signing key
+    ///   - signer: A closure that signs message data and returns the signature
+    /// - Returns: Self for method chaining
+    @discardableResult
+    public func setOperatorWith(
+        _ accountId: AccountId,
+        _ publicKey: PublicKey,
+        _ signer: @Sendable @escaping (Data) -> Data
+    ) -> Self {
+        _operator.withLockedValue {
+            $0 = Operator(accountId: accountId, signer: Signer(publicKey, signer))
+        }
+
+        return self
+    }
+
     /// Sets the maximum transaction fee used when freezing transactions.
     @discardableResult
     internal func setMaxTransactionFee(_ maxTransactionFee: Hbar) -> Self {

--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -518,7 +518,7 @@ public final class Client: Sendable {
     ) -> Self {
         _operator.withLockedValue { op in
             op = Operator(accountId: accountId, signer: Signer(publicKey, signer))
-       }
+        }
 
         return self
     }

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -214,7 +214,7 @@ internal final class ClientUnitTests: HieroUnitTestCase {
     }
 }
 
-internal final class ClientOperatorUnitTests: XCTestCase {
+internal final class ClientOperatorUnitTests: HieroUnitTestCase {
     internal func test_SetOperatorWithUsesCustomSignerAndPublicKey() throws {
         let client = try Client.forNetwork([String: AccountId]())
         let operatorId = AccountId(shard: 0, realm: 0, num: 3)

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import Atomics
 import HieroTestSupport
 import XCTest
 
@@ -210,5 +211,32 @@ internal final class ClientUnitTests: HieroUnitTestCase {
         let returnedClient = client.setOperator(operatorId, privateKey)
 
         XCTAssertTrue(client === returnedClient)
+    }
+}
+
+internal final class ClientOperatorUnitTests: XCTestCase {
+    internal func test_SetOperatorWithUsesCustomSignerAndPublicKey() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+        let operatorId = AccountId(shard: 0, realm: 0, num: 3)
+        let privateKey = PrivateKey.generateEd25519()
+        let publicKey = privateKey.publicKey
+
+        let signerCalled = ManagedAtomic<Bool>(false)
+        let signer: @Sendable (Data) -> Data = { data in
+            signerCalled.store(true, ordering: .relaxed)
+            return privateKey.sign(data)
+        }
+
+        client.setOperatorWith(operatorId, publicKey, signer)
+
+        XCTAssertEqual(client.`operator`?.signer.publicKey, publicKey)
+
+        let transaction = FreezeTransaction()
+            .nodeAccountIds([operatorId])
+
+        try transaction.signWithOperator(client)
+        _ = try transaction.getSignatures()
+
+        XCTAssertTrue(signerCalled.load(ordering: .relaxed))
     }
 }

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -195,7 +195,7 @@ internal final class ClientUnitTests: HieroUnitTestCase {
 
     internal func test_GetOperatorAccountIdReturnsAccountIdWhenSet() throws {
         let client = try Client.forNetwork([String: AccountId]())
-        let operatorId = try AccountId(shard: 0, realm: 0, num: 3)
+        let operatorId = AccountId(shard: 0, realm: 0, num: 3)
         let privateKey = PrivateKey.generateEd25519()
 
         client.setOperator(operatorId, privateKey)
@@ -205,7 +205,7 @@ internal final class ClientUnitTests: HieroUnitTestCase {
 
     internal func test_SetOperatorReturnsClientForFluentInterface() throws {
         let client = try Client.forNetwork([String: AccountId]())
-        let operatorId = try AccountId(shard: 0, realm: 0, num: 3)
+        let operatorId = AccountId(shard: 0, realm: 0, num: 3)
         let privateKey = PrivateKey.generateEd25519()
 
         let returnedClient = client.setOperator(operatorId, privateKey)


### PR DESCRIPTION
Closes #545

Added `setOperatorWith()` to the `Client` class that accepts an `AccountId`, 
`PublicKey`, and a custom signing closure instead of a raw `PrivateKey`.

## Changes
- Added `setOperatorWith()` in `Sources/Hiero/Client/Client.swift`
- Added unit test in `Tests/HieroTests/`

## Testing
- All existing tests pass
- New unit test added and passing

## Checklist
- [ ] Scoped to this issue only
- [ ] No existing behavior changed
- [ ] Commits signed with `-s` and `-S`