### PR TITLE
Default max query payment

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -54,6 +54,9 @@ public final class Client: Sendable {
     /// Maximum transaction fee in tinybars (0 = no limit)
     private let _maxTransactionFee: ManagedAtomic<Int64>
 
+    /// Maximum query payment in tinybars (0 = no limit)
+    private let _maxQueryPayment: ManagedAtomic<Int64>
+
     /// Network update period in nanoseconds
     private let _networkUpdatePeriod: NIOLockedValueBox<UInt64?>
 
@@ -102,6 +105,7 @@ public final class Client: Sendable {
         self._autoValidateChecksums = .init(false)  // Checksums disabled by default for performance
         self._regenerateTransactionId = .init(true)  // Auto-regenerate expired transaction IDs by default
         self._maxTransactionFee = .init(0)  // 0 = no fee limit (use network defaults)
+        self._maxQueryPayment = .init(100_000_000)  // Default: 1 Hbar
         self.networkUpdateTask = NetworkUpdateTask(
             eventLoop: eventLoop,
             consensusNetwork: _consensusNetwork,
@@ -145,6 +149,11 @@ public final class Client: Sendable {
         }
 
         return .fromTinybars(value)
+    }
+
+    /// Maximum query payment, or nil if unlimited
+    internal var defaultMaxQueryPayment: Hbar? {
+        getDefaultMaxQueryPayment()  // delegate, don't duplicate
     }
 
     /// Whether this client should use only plaintext endpoints.
@@ -556,6 +565,26 @@ public final class Client: Sendable {
     internal func setMaxTransactionFee(_ maxTransactionFee: Hbar) -> Self {
         _maxTransactionFee.store(maxTransactionFee.toTinybars(), ordering: .relaxed)
 
+        return self
+    }
+
+    /// Returns the default maximum query payment, or `nil` if unlimited.
+    /// Defaults to 1 Hbar.
+    public func getDefaultMaxQueryPayment() -> Hbar? {
+        let value = _maxQueryPayment.load(ordering: .relaxed)
+        guard value != 0 else { return nil }
+        return .fromTinybars(value)
+    }
+
+    /// Sets the default maximum query payment for all queries.
+    /// - Parameter payment: Must be non-negative.
+    /// - Throws: `HError` with `.invalidArgument` if payment is negative.
+    @discardableResult
+    public func setDefaultMaxQueryPayment(_ payment: Hbar) throws -> Self {
+        guard payment.toTinybars() >= 0 else {
+            throw HError(kind: .invalidArgument, description: "defaultMaxQueryPayment must be non-negative")
+        }
+        _maxQueryPayment.store(payment.toTinybars(), ordering: .relaxed)
         return self
     }
 

--- a/Sources/Hiero/HError.swift
+++ b/Sources/Hiero/HError.swift
@@ -17,6 +17,7 @@ public struct HError: Error, CustomStringConvertible {
         case keyParse
         case keyDerive
         case noPayerAccountOrTransactionId
+        case invalidArgument
         case maxQueryPaymentExceeded(queryCost: Hbar, maxQueryPayment: Hbar)
         case nodeAccountUnknown
         case responseStatusUnrecognized

--- a/Sources/Hiero/Query.swift
+++ b/Sources/Hiero/Query.swift
@@ -167,8 +167,8 @@ public class Query<Response>: ValidateChecksums {
                 // should this inherit the timeout?
                 // payment is required but none was specified, query the cost
                 let cost = try await self.getCost(client)
-
-                if let maxAmount = self.payment.maxAmount {
+                let effectiveMax = self.payment.maxAmount ?? client.defaultMaxQueryPayment
+                if let maxAmount = effectiveMax {
                     guard cost <= maxAmount else {
                         throw HError.maxQueryPaymentExceeded(queryCost: cost, maxQueryPayment: maxAmount)
                     }

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -221,9 +221,14 @@ internal final class ClientUnitTests: HieroUnitTestCase {
         let client = try Client.forNetwork([String: AccountId]())
 
         XCTAssertThrowsError(try client.setDefaultMaxTransactionFee(.fromTinybars(-1))) { error in
-        let client = try Client.forNetwork([String: AccountId]())
+            guard let hError = error as? HError else {
+                XCTFail("Expected HError, got \(type(of: error))")
+                return
+            }
 
-        XCTAssertEqual(client.getDefaultMaxQueryPayment(), Hbar.fromTinybars(100_000_000))
+            XCTAssertEqual(hError.kind, .illegalState)
+            XCTAssertTrue(hError.description.contains("non-negative"))
+        }
     }
 
     internal func test_SetDefaultMaxQueryPaymentRoundTripsCorrectly() throws {
@@ -247,10 +252,6 @@ internal final class ClientUnitTests: HieroUnitTestCase {
 
             XCTAssertEqual(hError.kind, .illegalState)
             XCTAssertTrue(hError.description.contains("non-negative"))
-        }
-    }
-
-            XCTAssertTrue(hError.description.contains("defaultMaxQueryPayment must be non-negative"))
         }
     }
 

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -224,7 +224,7 @@ internal final class ClientUnitTests: HieroUnitTestCase {
             guard let hError = error as? HError else {
                 XCTFail("Expected HError, got \(type(of: error))")
                 return
-            }
+         }
 
             XCTAssertEqual(hError.kind, .illegalState)
             XCTAssertTrue(hError.description.contains("non-negative"))

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -221,6 +221,25 @@ internal final class ClientUnitTests: HieroUnitTestCase {
         let client = try Client.forNetwork([String: AccountId]())
 
         XCTAssertThrowsError(try client.setDefaultMaxTransactionFee(.fromTinybars(-1))) { error in
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertEqual(client.getDefaultMaxQueryPayment(), Hbar.fromTinybars(100_000_000))
+    }
+
+    internal func test_SetDefaultMaxQueryPaymentRoundTripsCorrectly() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+        let newMax = Hbar.fromTinybars(50_000_000)
+
+        try client.setDefaultMaxQueryPayment(newMax)
+
+        XCTAssertEqual(client.getDefaultMaxQueryPayment(), newMax)
+    }
+
+    internal func test_SetDefaultMaxQueryPaymentThrowsForNegativeValue() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+        let negativePayment = Hbar.fromTinybars(-1)
+
+        XCTAssertThrowsError(try client.setDefaultMaxQueryPayment(negativePayment)) { error in
             guard let hError = error as? HError else {
                 XCTFail("Expected HError, got \(type(of: error))")
                 return
@@ -229,6 +248,18 @@ internal final class ClientUnitTests: HieroUnitTestCase {
             XCTAssertEqual(hError.kind, .illegalState)
             XCTAssertTrue(hError.description.contains("non-negative"))
         }
+    }
+
+            XCTAssertTrue(hError.description.contains("defaultMaxQueryPayment must be non-negative"))
+        }
+    }
+
+    internal func test_SetDefaultMaxQueryPaymentZeroReturnsNil() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        try client.setDefaultMaxQueryPayment(Hbar.fromTinybars(0))
+
+        XCTAssertNil(client.getDefaultMaxQueryPayment())
     }
 
     // MARK: - Operator Tests
@@ -261,6 +292,7 @@ internal final class ClientUnitTests: HieroUnitTestCase {
 }
 
 internal final class ClientOperatorUnitTests: HieroUnitTestCase {
+
     internal func test_SetOperatorWithUsesCustomSignerAndPublicKey() throws {
         let client = try Client.forNetwork([String: AccountId]())
         let operatorId = AccountId(shard: 0, realm: 0, num: 3)


### PR DESCRIPTION
**Description**:
**Add `defaultMaxQueryPayment` to `Client`**

Adds `getDefaultMaxQueryPayment()` and `setDefaultMaxQueryPayment()` to `Client.swift`, matching the existing `maxTransactionFee` pattern. Defaults to 1 Hbar, returns `nil` when set to zero (unlimited), and throws  `HError(.invalidArgument)` on negative values. Includes an internal accessor for use by `Query` and unit tests covering default value, round-trip, zero, and negative cases. Brings the Swift SDK in line with Java, Go, Python, and Rust implementation.
Closes #543