### PR TITLE
feat: add default maximum transaction fee management to Client

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -179,6 +179,32 @@ public final class Client: Sendable {
         return _realm
     }
 
+    /// Returns the default maximum transaction fee, or nil if unlimited.
+    ///
+    /// When set, this fee is used as the default for all transactions unless
+    /// explicitly overridden on the transaction itself.
+    public func getDefaultMaxTransactionFee() -> Hbar? {
+        maxTransactionFee
+    }
+
+    /// Sets the default maximum transaction fee for all transactions.
+    ///
+    /// - Parameter fee: The maximum fee in Hbar. Must be non-negative.
+    /// - Returns: Self for method chaining
+    /// - Throws: `HError.illegalState` if `fee` is negative.
+    @discardableResult
+    public func setDefaultMaxTransactionFee(_ fee: Hbar) throws -> Self {
+        let tinybars = fee.toTinybars()
+
+        guard tinybars >= 0 else {
+            throw HError.illegalState("defaultMaxTransactionFee must be non-negative")
+        }
+
+        _maxTransactionFee.store(tinybars, ordering: .relaxed)
+
+        return self
+    }
+
     // MARK: - Retry Configuration
 
     /// Maximum timeout for a single gRPC request before it's considered failed.

--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -190,6 +190,8 @@ public final class Client: Sendable {
     /// Sets the default maximum transaction fee for all transactions.
     ///
     /// - Parameter fee: The maximum fee in Hbar. Must be non-negative.
+    ///   A value of zero clears the default fee limit, equivalent to not having set one
+    ///   (i.e., `getDefaultMaxTransactionFee()` will return `nil`).
     /// - Returns: Self for method chaining
     /// - Throws: `HError.illegalState` if `fee` is negative.
     @discardableResult

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -185,6 +185,52 @@ internal final class ClientUnitTests: HieroUnitTestCase {
         XCTAssertEqual(client.grpcDeadline, 300.0)
     }
 
+    // MARK: - Default Max Transaction Fee Tests
+
+    internal func test_GetDefaultMaxTransactionFeeReturnsNilByDefault() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertNil(client.getDefaultMaxTransactionFee())
+    }
+
+    internal func test_SetDefaultMaxTransactionFeeStoresValue() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+        let fee = Hbar.fromTinybars(100_000)
+
+        try client.setDefaultMaxTransactionFee(fee)
+
+        XCTAssertEqual(client.getDefaultMaxTransactionFee(), fee)
+    }
+
+    internal func test_SetDefaultMaxTransactionFeeReturnsClientForFluentInterface() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+        let returnedClient = try client.setDefaultMaxTransactionFee(.fromTinybars(100_000))
+
+        XCTAssertTrue(client === returnedClient)
+    }
+
+    internal func test_SetDefaultMaxTransactionFeeZeroReturnsNilWhenRead() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        try client.setDefaultMaxTransactionFee(.fromTinybars(0))
+
+        XCTAssertNil(client.getDefaultMaxTransactionFee())
+    }
+
+    internal func test_SetDefaultMaxTransactionFeeThrowsWhenNegative() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertThrowsError(try client.setDefaultMaxTransactionFee(.fromTinybars(-1))) { error in
+            guard let hError = error as? HError else {
+                XCTFail("Expected HError, got \(type(of: error))")
+                return
+            }
+
+            XCTAssertEqual(hError.kind, .illegalState)
+            XCTAssertTrue(hError.description.contains("non-negative"))
+        }
+    }
+
     // MARK: - Operator Tests
 
     internal func test_GetOperatorAccountIdReturnsNilWhenNotSet() throws {


### PR DESCRIPTION
**Description**:
This pull request adds support for configuring a default maximum transaction fee in the `Client` class, along with comprehensive unit tests to verify its behavior. The main focus is on providing a fluent interface for setting and retrieving this default fee, as well as ensuring correct handling of edge cases such as negative or zero values.

Enhancements to transaction fee configuration:

* Added `getDefaultMaxTransactionFee()` and `setDefaultMaxTransactionFee(_:)` methods to the `Client` class, allowing users to get or set a default maximum transaction fee for all transactions, with validation to prevent negative values. (`Sources/Hiero/Client/Client.swift`, [Sources/Hiero/Client/Client.swiftR182-R207](diffhunk://#diff-b8218ee329547bda3d2518a5d9a007b4e8bbb4549b2bdd5c224b9c578571ba6aR182-R207))

Testing and validation:

* Introduced a suite of unit tests to verify the default behavior, correct storage, fluent interface, handling of zero values, and error throwing for negative fees in the `Client` class. (`Tests/HieroUnitTests/ClientUnitTests.swift`, [Tests/HieroUnitTests/ClientUnitTests.swiftR188-R233](diffhunk://#diff-cd59de9ffbdecc2f8f3ef79446b416f01db6d7d23d2997eec807457188c965afR188-R233))
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #542 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
