### PR TITLE
refactor: move environment loading to HieroIntegrationTestCase setup

### DIFF
--- a/Tests/HieroTestSupport/Base/HieroIntegrationTestCase.swift
+++ b/Tests/HieroTestSupport/Base/HieroIntegrationTestCase.swift
@@ -15,6 +15,14 @@ open class HieroIntegrationTestCase: HieroTestCase {
     open override func setUp() async throws {
         try await super.setUp()
 
+        // Integration tests require .env configuration and operator credentials.
+        DotenvLoader.ensureLoaded()
+        do {
+            try TestEnvironmentConfig.ensureLoaded()
+        } catch {
+            throw XCTSkip("Failed to load test environment configuration: \(error)")
+        }
+
         // Create test environment (validates config and operator)
         testEnv = try await IntegrationTestEnvironment.create()
 

--- a/Tests/HieroTestSupport/Base/HieroIntegrationTestCase.swift
+++ b/Tests/HieroTestSupport/Base/HieroIntegrationTestCase.swift
@@ -15,8 +15,7 @@ open class HieroIntegrationTestCase: HieroTestCase {
     open override func setUp() async throws {
         try await super.setUp()
 
-        // Integration tests require .env configuration and operator credentials.
-        DotenvLoader.ensureLoaded()
+        // Integration tests require operator credentials.
         do {
             try TestEnvironmentConfig.ensureLoaded()
         } catch {

--- a/Tests/HieroTestSupport/Base/HieroTestCase.swift
+++ b/Tests/HieroTestSupport/Base/HieroTestCase.swift
@@ -8,13 +8,5 @@ import XCTest
 open class HieroTestCase: XCTestCase {
     open override func setUp() async throws {
         try await super.setUp()
-
-        // Ensure .env and config are loaded (will throw XCTSkip if config fails)
-        DotenvLoader.ensureLoaded()
-        do {
-            try TestEnvironmentConfig.ensureLoaded()
-        } catch {
-            throw XCTSkip("Failed to load test environment configuration: \(error)")
-        }
     }
 }

--- a/Tests/HieroTestSupport/Base/HieroTestCase.swift
+++ b/Tests/HieroTestSupport/Base/HieroTestCase.swift
@@ -8,5 +8,6 @@ import XCTest
 open class HieroTestCase: XCTestCase {
     open override func setUp() async throws {
         try await super.setUp()
+        DotenvLoader.ensureLoaded()
     }
 }


### PR DESCRIPTION
**Description**:
This pull request refactors the loading of environment and configuration files for test cases. The main change is moving the responsibility for loading `.env` and test environment configuration from the base test case class to the integration test case class. This ensures that only integration tests require these configurations, simplifying the setup for other test cases.

Test setup refactoring:

* Removed loading of `.env` and test environment configuration from the `HieroTestCase` base class, so these are no longer required for all test cases (`Tests/HieroTestSupport/Base/HieroTestCase.swift`).
* Added loading of `.env` and test environment configuration to the `HieroIntegrationTestCase` class, ensuring integration tests still require and validate these settings (`Tests/HieroTestSupport/Base/HieroIntegrationTestCase.swift`).
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #607 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
