### PR TITLE
feat: add minimum and maximum node readmit time configuration to Client and ConsensusNetwork

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -314,10 +314,7 @@ public final class Client: Sendable {
             )
         }
 
-        _ = _consensusNetwork.readCopyUpdate { current in
-            current.setMinNodeReadmitTime(time)
-            return current
-        }
+        consensus.setMinNodeReadmitTime(time)
 
         return self
     }
@@ -348,10 +345,7 @@ public final class Client: Sendable {
             )
         }
 
-        _ = _consensusNetwork.readCopyUpdate { current in
-            current.setMaxNodeReadmitTime(time)
-            return current
-        }
+        consensus.setMaxNodeReadmitTime(time)
 
         return self
     }

--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -288,6 +288,74 @@ public final class Client: Sendable {
         set(value) { _backoff.withLockedValue { $0.maxBackoff = value } }
     }
 
+    /// Gets the minimum time before a failed node can be retried.
+    ///
+    /// This maps to the initial node health backoff interval.
+    public func getMinNodeReadmitTime() -> TimeInterval {
+        consensus.getMinNodeReadmitTime()
+    }
+
+    /// Sets the minimum time before a failed node can be retried.
+    ///
+    /// - Parameter time: Time in seconds. Must be non-negative and less than or equal to maxNodeReadmitTime.
+    /// - Returns: Self for method chaining
+    /// - Throws: `HError.illegalState` if `time` is invalid.
+    @discardableResult
+    public func setMinNodeReadmitTime(_ time: TimeInterval) throws -> Self {
+        guard time >= 0 else {
+            throw HError.illegalState("minNodeReadmitTime must be non-negative")
+        }
+
+        let maxReadmitTime = getMaxNodeReadmitTime()
+
+        guard time <= maxReadmitTime else {
+            throw HError.illegalState(
+                "minNodeReadmitTime (\(time)s) must be <= maxNodeReadmitTime (\(maxReadmitTime)s)"
+            )
+        }
+
+        _ = _consensusNetwork.readCopyUpdate { current in
+            current.setMinNodeReadmitTime(time)
+            return current
+        }
+
+        return self
+    }
+
+    /// Gets the maximum time a failed node remains excluded before retry.
+    ///
+    /// This maps to the circuit-open recovery duration.
+    public func getMaxNodeReadmitTime() -> TimeInterval {
+        consensus.getMaxNodeReadmitTime()
+    }
+
+    /// Sets the maximum time a failed node remains excluded before retry.
+    ///
+    /// - Parameter time: Time in seconds. Must be non-negative and greater than or equal to minNodeReadmitTime.
+    /// - Returns: Self for method chaining
+    /// - Throws: `HError.illegalState` if `time` is invalid.
+    @discardableResult
+    public func setMaxNodeReadmitTime(_ time: TimeInterval) throws -> Self {
+        guard time >= 0 else {
+            throw HError.illegalState("maxNodeReadmitTime must be non-negative")
+        }
+
+        let minReadmitTime = getMinNodeReadmitTime()
+
+        guard time >= minReadmitTime else {
+            throw HError.illegalState(
+                "maxNodeReadmitTime (\(time)s) must be >= minNodeReadmitTime (\(minReadmitTime)s)"
+            )
+        }
+
+        _ = _consensusNetwork.readCopyUpdate { current in
+            current.setMaxNodeReadmitTime(time)
+            return current
+        }
+
+        return self
+    }
+
     /// Current backoff configuration
     internal var backoff: Backoff {
         self._backoff.withLockedValue { $0 }

--- a/Sources/Hiero/Client/ConsensusNetwork.swift
+++ b/Sources/Hiero/Client/ConsensusNetwork.swift
@@ -22,6 +22,12 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
         NodeConnection.consensusPlaintextPort: 1,
     ]
 
+    /// Default minimum time (in seconds) before retrying a failed node
+    internal static let defaultMinNodeReadmitTime: TimeInterval = 0.25
+
+    /// Default maximum time (in seconds) before forcing retry of a failed node
+    internal static let defaultMaxNodeReadmitTime: TimeInterval = 5 * 60
+
     // MARK: - Properties
 
     /// Maps account IDs to their index in the nodes array
@@ -75,8 +81,8 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
             nodes: config.nodes,
             health: health,
             connections: connections,
-            minNodeReadmitTime: .init(0.25),
-            maxNodeReadmitTime: .init(5 * 60)
+            minNodeReadmitTime: .init(Self.defaultMinNodeReadmitTime),
+            maxNodeReadmitTime: .init(Self.defaultMaxNodeReadmitTime)
         )
     }
 
@@ -92,8 +98,8 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
                 nodes: [],
                 health: [],
                 connections: [],
-                minNodeReadmitTime: .init(0.25),
-                maxNodeReadmitTime: .init(5 * 60)
+                minNodeReadmitTime: .init(Self.defaultMinNodeReadmitTime),
+                maxNodeReadmitTime: .init(Self.defaultMaxNodeReadmitTime)
             ),
             addresses: addresses,
             eventLoop: eventLoop

--- a/Sources/Hiero/Client/ConsensusNetwork.swift
+++ b/Sources/Hiero/Client/ConsensusNetwork.swift
@@ -428,8 +428,8 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
         let minReadmitTime = minNodeReadmitTime.withLockedValue { $0 }
         let maxReadmitTime = maxNodeReadmitTime.withLockedValue { $0 }
 
-        nodeHealthStates[index].withLockedValue {
-            $0.markUnhealthy(at: .now, minNodeReadmitTime: minReadmitTime, maxNodeReadmitTime: maxReadmitTime)
+        nodeHealthStates[index].withLockedValue { health in
+            health.markUnhealthy(at: .now, minNodeReadmitTime: minReadmitTime, maxNodeReadmitTime: maxReadmitTime)
         }
     }
 

--- a/Sources/Hiero/Client/ConsensusNetwork.swift
+++ b/Sources/Hiero/Client/ConsensusNetwork.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Atomics
+import Foundation
 import GRPC
 import NIOConcurrencyHelpers
 import NIOCore
@@ -35,6 +36,12 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
     /// GRPC connections to each node
     private let nodeConnections: [NodeConnection]
 
+    /// Minimum time before retrying a failed node
+    private let minNodeReadmitTime: NIOLockedValueBox<TimeInterval>
+
+    /// Maximum time before forcing retry of a failed node
+    private let maxNodeReadmitTime: NIOLockedValueBox<TimeInterval>
+
     // MARK: - Initialization
 
     /// Internal initializer for creating a consensus network.
@@ -42,12 +49,16 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
         map: [AccountId: Int],
         nodes: [AccountId],
         health: [NIOLockedValueBox<NodeHealth>],
-        connections: [NodeConnection]
+        connections: [NodeConnection],
+        minNodeReadmitTime: NIOLockedValueBox<TimeInterval>,
+        maxNodeReadmitTime: NIOLockedValueBox<TimeInterval>
     ) {
         self.nodeIndexMap = map
         self.nodes = nodes
         self.nodeHealthStates = health
         self.nodeConnections = connections
+        self.minNodeReadmitTime = minNodeReadmitTime
+        self.maxNodeReadmitTime = maxNodeReadmitTime
     }
 
     /// Creates a consensus network from configuration.
@@ -63,7 +74,9 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
             map: config.nodeIndexMap,
             nodes: config.nodes,
             health: health,
-            connections: connections
+            connections: connections,
+            minNodeReadmitTime: .init(0.25),
+            maxNodeReadmitTime: .init(5 * 60)
         )
     }
 
@@ -74,9 +87,25 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
     ///   - eventLoop: Event loop for managing connections
     internal convenience init(addresses: [String: AccountId], eventLoop: EventLoop) throws {
         let tmp = try Self.withAddresses(
-            Self(map: [:], nodes: [], health: [], connections: []), addresses: addresses, eventLoop: eventLoop)
+            Self(
+                map: [:],
+                nodes: [],
+                health: [],
+                connections: [],
+                minNodeReadmitTime: .init(0.25),
+                maxNodeReadmitTime: .init(5 * 60)
+            ),
+            addresses: addresses,
+            eventLoop: eventLoop
+        )
         self.init(
-            map: tmp.nodeIndexMap, nodes: tmp.nodes, health: tmp.nodeHealthStates, connections: tmp.nodeConnections)
+            map: tmp.nodeIndexMap,
+            nodes: tmp.nodes,
+            health: tmp.nodeHealthStates,
+            connections: tmp.nodeConnections,
+            minNodeReadmitTime: tmp.minNodeReadmitTime,
+            maxNodeReadmitTime: tmp.maxNodeReadmitTime
+        )
     }
 
     // MARK: - Computed Properties
@@ -233,7 +262,9 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
             map: map,
             nodes: nodeIds,
             health: health,
-            connections: connections
+            connections: connections,
+            minNodeReadmitTime: old.minNodeReadmitTime,
+            maxNodeReadmitTime: old.maxNodeReadmitTime
         )
     }
 
@@ -294,8 +325,28 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
             map: map,
             nodes: nodeIds,
             health: health,
-            connections: connections
+            connections: connections,
+            minNodeReadmitTime: old.minNodeReadmitTime,
+            maxNodeReadmitTime: old.maxNodeReadmitTime
         )
+    }
+
+    // MARK: - Node Readmit Configuration
+
+    internal func getMinNodeReadmitTime() -> TimeInterval {
+        minNodeReadmitTime.withLockedValue { $0 }
+    }
+
+    internal func setMinNodeReadmitTime(_ time: TimeInterval) {
+        minNodeReadmitTime.withLockedValue { $0 = time }
+    }
+
+    internal func getMaxNodeReadmitTime() -> TimeInterval {
+        maxNodeReadmitTime.withLockedValue { $0 }
+    }
+
+    internal func setMaxNodeReadmitTime(_ time: TimeInterval) {
+        maxNodeReadmitTime.withLockedValue { $0 = time }
     }
 
     // MARK: - Channel Access
@@ -374,7 +425,12 @@ internal final class ConsensusNetwork: Sendable, AtomicReference {
     ///
     /// - Parameter index: Index of the node to mark unhealthy
     internal func markNodeUnhealthy(at index: Int) {
-        nodeHealthStates[index].withLockedValue { $0.markUnhealthy(at: .now) }
+        let minReadmitTime = minNodeReadmitTime.withLockedValue { $0 }
+        let maxReadmitTime = maxNodeReadmitTime.withLockedValue { $0 }
+
+        nodeHealthStates[index].withLockedValue {
+            $0.markUnhealthy(at: .now, minNodeReadmitTime: minReadmitTime, maxNodeReadmitTime: maxReadmitTime)
+        }
     }
 
     /// Marks a node as healthy and resets its backoff timer.

--- a/Sources/Hiero/Client/NodeHealth.swift
+++ b/Sources/Hiero/Client/NodeHealth.swift
@@ -53,12 +53,6 @@ internal enum NodeHealth: Sendable {
     /// Maximum consecutive failures before opening the circuit (5 failures)
     private static let maxConsecutiveFailures = 5
 
-    /// Duration to keep circuit open before testing recovery (5 minutes)
-    private static let circuitOpenDurationNanos: UInt64 = TimeInterval(5 * 60).nanoseconds
-
-    /// Initial backoff interval for first failure (250 milliseconds)
-    private static let initialBackoffInterval: TimeInterval = 0.25
-
     /// Maximum backoff interval before circuit opens (30 minutes)
     private static let maxBackoffInterval: TimeInterval = 30 * 60
 
@@ -70,9 +64,9 @@ internal enum NodeHealth: Sendable {
     /// The exponential backoff configuration for this node.
     ///
     /// Backoff intervals range from 250ms to 30 minutes, with no maximum elapsed time.
-    internal var backoff: ExponentialBackoff {
+    internal func backoff(minNodeReadmitTime: TimeInterval) -> ExponentialBackoff {
         var backoff = ExponentialBackoff(
-            initialInterval: Self.initialBackoffInterval,
+            initialInterval: minNodeReadmitTime,
             maxInterval: Self.maxBackoffInterval,
             maxElapsedTime: .unlimited
         )
@@ -94,7 +88,11 @@ internal enum NodeHealth: Sendable {
     /// - Otherwise, applies exponential backoff
     ///
     /// - Parameter now: Current timestamp
-    internal mutating func markUnhealthy(at now: Timestamp) {
+    internal mutating func markUnhealthy(
+        at now: Timestamp,
+        minNodeReadmitTime: TimeInterval,
+        maxNodeReadmitTime: TimeInterval
+    ) {
         let consecutiveFailures: Int
 
         switch self {
@@ -109,13 +107,13 @@ internal enum NodeHealth: Sendable {
 
         // Open circuit after too many consecutive failures
         if consecutiveFailures >= Self.maxConsecutiveFailures {
-            let reopenAt = now.adding(nanos: Self.circuitOpenDurationNanos)
+            let reopenAt = now.adding(nanos: maxNodeReadmitTime.nanoseconds)
             self = .circuitOpen(reopenAt: reopenAt)
             return
         }
 
         // Apply exponential backoff
-        var backoff = self.backoff
+        var backoff = self.backoff(minNodeReadmitTime: minNodeReadmitTime)
         let backoffInterval = backoff.next()!  // Safe: backoff has unlimited max elapses time (never returns nil)
         let healthyAt = now.adding(nanos: backoffInterval.nanoseconds)
 

--- a/Sources/Hiero/Client/NodeHealth.swift
+++ b/Sources/Hiero/Client/NodeHealth.swift
@@ -15,8 +15,9 @@ import Foundation
 /// ## Circuit Breaker Pattern
 /// The circuit breaker prevents wasted retries on nodes that are consistently failing
 /// by transitioning to `circuitOpen` after multiple consecutive failures (5 by default).
-/// After a recovery period (5 minutes), the circuit transitions to half-open (unhealthy
-/// with minimal backoff) to test if the node has recovered.
+/// After the configured recovery period (default: 5 minutes, see `Client.setMaxNodeReadmitTime`),
+/// the circuit transitions to half-open (unhealthy with minimal backoff) to test if the node
+/// has recovered.
 ///
 /// ## State Diagram
 /// ```

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -16,6 +16,116 @@ internal final class ClientUnitTests: HieroUnitTestCase {
         XCTAssertEqual(client.getRealm(), realm)
     }
 
+    // MARK: - Node Readmit Time Tests
+
+    internal func test_NodeReadmitTimesDefaultValues() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertEqual(client.getMinNodeReadmitTime(), 0.25)
+        XCTAssertEqual(client.getMaxNodeReadmitTime(), 300.0)
+    }
+
+    internal func test_SetMinNodeReadmitTimeStoresValue() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        try client.setMinNodeReadmitTime(1.5)
+
+        XCTAssertEqual(client.getMinNodeReadmitTime(), 1.5)
+    }
+
+    internal func test_SetMaxNodeReadmitTimeStoresValue() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        try client.setMaxNodeReadmitTime(600.0)
+
+        XCTAssertEqual(client.getMaxNodeReadmitTime(), 600.0)
+    }
+
+    internal func test_SetMinNodeReadmitTimeReturnsClientForFluentInterface() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        let returnedClient = try client.setMinNodeReadmitTime(1.0)
+
+        XCTAssertTrue(client === returnedClient)
+    }
+
+    internal func test_SetMaxNodeReadmitTimeReturnsClientForFluentInterface() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        let returnedClient = try client.setMaxNodeReadmitTime(600.0)
+
+        XCTAssertTrue(client === returnedClient)
+    }
+
+    internal func test_SetMinNodeReadmitTimeThrowsWhenNegative() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertThrowsError(try client.setMinNodeReadmitTime(-0.1)) { error in
+            guard let hError = error as? HError else {
+                XCTFail("Expected HError, got \(type(of: error))")
+                return
+            }
+
+            XCTAssertEqual(hError.kind, .illegalState)
+            XCTAssertTrue(hError.description.contains("minNodeReadmitTime"))
+        }
+    }
+
+    internal func test_SetMaxNodeReadmitTimeThrowsWhenNegative() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertThrowsError(try client.setMaxNodeReadmitTime(-1.0)) { error in
+            guard let hError = error as? HError else {
+                XCTFail("Expected HError, got \(type(of: error))")
+                return
+            }
+
+            XCTAssertEqual(hError.kind, .illegalState)
+            XCTAssertTrue(hError.description.contains("maxNodeReadmitTime"))
+        }
+    }
+
+    internal func test_SetMinNodeReadmitTimeThrowsWhenGreaterThanMax() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+
+        XCTAssertThrowsError(try client.setMinNodeReadmitTime(301.0)) { error in
+            guard let hError = error as? HError else {
+                XCTFail("Expected HError, got \(type(of: error))")
+                return
+            }
+
+            XCTAssertEqual(hError.kind, .illegalState)
+            XCTAssertTrue(hError.description.contains("<= maxNodeReadmitTime"))
+        }
+    }
+
+    internal func test_SetMaxNodeReadmitTimeThrowsWhenLessThanMin() throws {
+        let client = try Client.forNetwork([String: AccountId]())
+        try client.setMinNodeReadmitTime(10.0)
+
+        XCTAssertThrowsError(try client.setMaxNodeReadmitTime(9.0)) { error in
+            guard let hError = error as? HError else {
+                XCTFail("Expected HError, got \(type(of: error))")
+                return
+            }
+
+            XCTAssertEqual(hError.kind, .illegalState)
+            XCTAssertTrue(hError.description.contains(">= minNodeReadmitTime"))
+        }
+    }
+
+    internal func test_NodeReadmitTimesPersistAfterNetworkReplacement() throws {
+        let client = try Client.forNetwork(["127.0.0.1:50211": AccountId(shard: 0, realm: 0, num: 3)])
+
+        try client.setMinNodeReadmitTime(2.0)
+        try client.setMaxNodeReadmitTime(20.0)
+
+        try client.setNetwork(["127.0.0.1:50212": AccountId(shard: 0, realm: 0, num: 4)])
+
+        XCTAssertEqual(client.getMinNodeReadmitTime(), 2.0)
+        XCTAssertEqual(client.getMaxNodeReadmitTime(), 20.0)
+    }
+
     // MARK: - gRPC Deadline Tests
 
     internal func test_GrpcDeadlineDefaultValue() throws {


### PR DESCRIPTION
**Description**:
This pull request introduces configurable node readmit timing to the client, allowing users to control how quickly failed nodes are retried after being marked unhealthy. The changes expose new methods for getting and setting the minimum and maximum node readmit times, ensure these values are validated and persisted across network updates, and add comprehensive tests for this new functionality.

**Node Readmit Timing Configuration:**

* Added `getMinNodeReadmitTime`, `setMinNodeReadmitTime`, `getMaxNodeReadmitTime`, and `setMaxNodeReadmitTime` methods to the `Client` class, allowing users to get/set the minimum and maximum time before a failed node is retried, with validation and fluent interface support.
* Updated the `ConsensusNetwork` class to store and manage `minNodeReadmitTime` and `maxNodeReadmitTime` as thread-safe, mutable values, and to propagate these values during network reconfiguration and node health updates. [[1]](diffhunk://#diff-0b6430f4a83d55484255a8711cb9a9e79a89182d20dcd3b0d79e3f99c5fafb12R39-R61) [[2]](diffhunk://#diff-0b6430f4a83d55484255a8711cb9a9e79a89182d20dcd3b0d79e3f99c5fafb12L66-R79) [[3]](diffhunk://#diff-0b6430f4a83d55484255a8711cb9a9e79a89182d20dcd3b0d79e3f99c5fafb12L77-R108) [[4]](diffhunk://#diff-0b6430f4a83d55484255a8711cb9a9e79a89182d20dcd3b0d79e3f99c5fafb12L236-R267) [[5]](diffhunk://#diff-0b6430f4a83d55484255a8711cb9a9e79a89182d20dcd3b0d79e3f99c5fafb12L297-R351) [[6]](diffhunk://#diff-0b6430f4a83d55484255a8711cb9a9e79a89182d20dcd3b0d79e3f99c5fafb12L377-R433)

**Node Health Logic:**

* Refactored the `NodeHealth` enum to use the configurable `minNodeReadmitTime` for exponential backoff and `maxNodeReadmitTime` for circuit-open recovery, replacing previous hardcoded values. [[1]](diffhunk://#diff-7bed4414eee4d53601f1750d28105f367dfc1aa8eb05cce3f7cc61814c40e18cL56-L61) [[2]](diffhunk://#diff-7bed4414eee4d53601f1750d28105f367dfc1aa8eb05cce3f7cc61814c40e18cL73-R69) [[3]](diffhunk://#diff-7bed4414eee4d53601f1750d28105f367dfc1aa8eb05cce3f7cc61814c40e18cL97-R95) [[4]](diffhunk://#diff-7bed4414eee4d53601f1750d28105f367dfc1aa8eb05cce3f7cc61814c40e18cL112-R116)

**Testing:**

* Added a comprehensive suite of unit tests to verify default values, value persistence, method chaining, error handling, and correct behavior when updating the network or setting invalid values for node readmit times.

**Other:**

* Minor import update to include Foundation in `ConsensusNetwork.swift` to support `TimeInterval` usage.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #550 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
