### PR TITLE
chore: release v0.51.0

### DIFF
--- a/Sources/Hiero/Version.swift
+++ b/Sources/Hiero/Version.swift
@@ -3,5 +3,5 @@
 /// Contains SDK version information.
 public enum VersionInfo {
     /// The current version of the Hiero SDK.
-    public static let version = "0.50.0-dev"
+    public static let version = "0.51.0"
 }


### PR DESCRIPTION
## Summary

Bumps `VersionInfo.version` from `0.50.0-dev` to `0.51.0` to cut the v0.51.0 release.

## Release Highlights

The following changes have landed on `main` since v0.50.0 and ship as part of this release.

### Features

| PR | Description |
|----|-------------|
| [#590](https://github.com/hiero-ledger/hiero-sdk-swift/pull/590) | Implement [HIP-1137](https://hips.hedera.com/hip/hip-1137) block node discoverability via on-chain registry |
| [#578](https://github.com/hiero-ledger/hiero-sdk-swift/pull/578) | Implement [HIP-1313](https://hips.hedera.com/hip/hip-1313) high-volume entity creation |
| [#526](https://github.com/hiero-ledger/hiero-sdk-swift/pull/526) | Implement [HIP-1261](https://hips.hedera.com/hip/hip-1261) fee estimation query |
| [#618](https://github.com/hiero-ledger/hiero-sdk-swift/pull/618) | Add minimum and maximum node readmit time configuration to `Client` and `ConsensusNetwork` |
| [#608](https://github.com/hiero-ledger/hiero-sdk-swift/pull/608) | Add default maximum transaction fee management to `Client` |
| [#605](https://github.com/hiero-ledger/hiero-sdk-swift/pull/605) | Add `setOperatorWith()` method to `Client` |
| [#601](https://github.com/hiero-ledger/hiero-sdk-swift/pull/601) | Add transaction signing for Hiero SDK |

### Maintenance

| PR | Description |
|----|-------------|
| [#620](https://github.com/hiero-ledger/hiero-sdk-swift/pull/620) | Upgrade solo version to v0.71.0 |
| [#619](https://github.com/hiero-ledger/hiero-sdk-swift/pull/619) | Unit tests for `EvmAddress` |
| [#609](https://github.com/hiero-ledger/hiero-sdk-swift/pull/609) | Move environment loading to `HieroIntegrationTestCase` setup |
| [#604](https://github.com/hiero-ledger/hiero-sdk-swift/pull/604) | Add doc comments to `EvmAddress.swift` |
| [#603](https://github.com/hiero-ledger/hiero-sdk-swift/pull/603) | Strip leading `v` prefix from version string in `Taskfile.yml` |
| [#613](https://github.com/hiero-ledger/hiero-sdk-swift/pull/613), [#614](https://github.com/hiero-ledger/hiero-sdk-swift/pull/614), [#616](https://github.com/hiero-ledger/hiero-sdk-swift/pull/616), [#617](https://github.com/hiero-ledger/hiero-sdk-swift/pull/617), [#621](https://github.com/hiero-ledger/hiero-sdk-swift/pull/621) | Dependency bumps (CI actions, setup-swift, harden-runner, hiero-solo-action) |

## Files Changed Summary

| File | Change |
|------|--------|
| `Sources/Hiero/Version.swift` | `0.50.0-dev` → `0.51.0` |

## Testing

```bash
swift build              # ✅ builds successfully
swift test               # ✅ existing test suite passes
```

No functional changes — version bump only. Underlying features were verified in their respective PRs.

## Breaking Changes

**None.**
