### PR TITLE
Feat/default max query payment

### DIFF
--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -551,6 +551,13 @@ public final class Client: Sendable {
         return client
     }
 
+    /// Returns the public key operator, or `nil` if no operator has been set.
+    ///
+    /// The operator's public key is derived from the private key or custom signer used to sign transactions.
+    public func getOperatorPublicKey() -> PublicKey? {
+        _operator.withLockedValue { $0?.signer.publicKey }
+    }
+
     /// Creates a client by network name (mainnet, testnet, previewnet, or localhost).
     ///
     /// - Parameter name: Network name ("mainnet", "testnet", "previewnet", or "localhost")

--- a/Sources/Hiero/Client/Client.swift
+++ b/Sources/Hiero/Client/Client.swift
@@ -54,6 +54,9 @@ public final class Client: Sendable {
     /// Maximum transaction fee in tinybars (0 = no limit)
     private let _maxTransactionFee: ManagedAtomic<Int64>
 
+    /// Maximum query payment in tinybars (0 = no limit)
+    private let _maxQueryPayment: ManagedAtomic<Int64>
+
     /// Network update period in nanoseconds
     private let _networkUpdatePeriod: NIOLockedValueBox<UInt64?>
 
@@ -102,6 +105,7 @@ public final class Client: Sendable {
         self._autoValidateChecksums = .init(false)  // Checksums disabled by default for performance
         self._regenerateTransactionId = .init(true)  // Auto-regenerate expired transaction IDs by default
         self._maxTransactionFee = .init(0)  // 0 = no fee limit (use network defaults)
+        self._maxQueryPayment = .init(100_000_000)  // Default: 1 Hbar
         self.networkUpdateTask = NetworkUpdateTask(
             eventLoop: eventLoop,
             consensusNetwork: _consensusNetwork,
@@ -167,6 +171,10 @@ public final class Client: Sendable {
         _mirrorNetwork.load(ordering: .relaxed)
     }
 
+    internal var defaultMaxQueryPayment: Hbar? {
+    getDefaultMaxQueryPayment()
+    }
+
     // MARK: - Public Accessors
 
     /// Returns the shard number for this client's network.
@@ -204,6 +212,23 @@ public final class Client: Sendable {
 
         _maxTransactionFee.store(tinybars, ordering: .relaxed)
 
+        return self
+    }
+
+    /// Returns the default maximum query payment, or `nil` if unlimited.
+    public func getDefaultMaxQueryPayment() -> Hbar? {
+        let value = _maxQueryPayment.load(ordering: .relaxed)
+        guard value != 0 else { return nil }
+        return .fromTinybars(value)
+}
+
+    /// Sets the default maximum query payment for all queries.
+    @discardableResult
+    public func setDefaultMaxQueryPayment(_ payment: Hbar) throws -> Self {
+        guard payment.toTinybars() >= 0 else {
+            throw HError.illegalState("defaultMaxQueryPayment must be non-negative")
+        }
+        _maxQueryPayment.store(payment.toTinybars(), ordering: .relaxed)
         return self
     }
 

--- a/Tests/HieroUnitTests/ClientTests.swift
+++ b/Tests/HieroUnitTests/ClientTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+@testable import Hiero
+
+internal final class ClientTests: XCTestCase {
+    internal func test_getOperatorPublicKey_returnsPublicKey() throws {
+        let privateKey = try PrivateKey.fromString(
+            "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10"
+        )
+        let accountId = try AccountId.fromString("0.0.1001")
+        let client = Client.forTestnet()
+
+        client.setOperator(accountId, privateKey)
+
+        let publicKey = client.getOperatorPublicKey()
+
+        XCTAssertNotNil(publicKey)
+        XCTAssertEqual(publicKey, privateKey.publicKey)
+    }
+
+    internal func test_getOperatorPublicKey_returnsNilWhenNoOPeratorSet() throws {
+        let client = Client.forTestnet()
+
+        XCTAssertNil(client.getOperatorPublicKey())
+    }
+}

--- a/Tests/HieroUnitTests/ClientTests.swift
+++ b/Tests/HieroUnitTests/ClientTests.swift
@@ -18,7 +18,7 @@ internal final class ClientTests: XCTestCase {
         XCTAssertEqual(publicKey, privateKey.publicKey)
     }
 
-    internal func test_getOperatorPublicKey_returnsNilWhenNoOPeratorSet() throws {
+    internal func test_getOperatorPublicKey_returnsNilWhenNoOperatorSet() throws {
         let client = Client.forTestnet()
 
         XCTAssertNil(client.getOperatorPublicKey())

--- a/Tests/HieroUnitTests/ClientTests.swift
+++ b/Tests/HieroUnitTests/ClientTests.swift
@@ -24,3 +24,21 @@ internal final class ClientTests: XCTestCase {
         XCTAssertNil(client.getOperatorPublicKey())
     }
 }
+
+extension ClientTests {
+    func testDefaultMaxQueryPaymentDefaultsToOneHbar() throws {
+        let client = Client.forTestnet()
+        XCTAssertEqual(client.getDefaultMaxQueryPayment(), Hbar.fromTinybars(100_000_000))
+    }
+
+    func testSetDefaultMaxQueryPayment() throws {
+        let client = Client.forTestnet()
+        try client.setDefaultMaxQueryPayment(Hbar(2))
+        XCTAssertEqual(client.getDefaultMaxQueryPayment(), Hbar(2))
+    }
+
+    func testNegativeMaxQueryPaymentThrows() throws {
+        let client = Client.forTestnet()
+        XCTAssertThrowsError(try client.setDefaultMaxQueryPayment(Hbar.fromTinybars(-1)))
+    }
+}

--- a/Tests/HieroUnitTests/ClientUnitTests.swift
+++ b/Tests/HieroUnitTests/ClientUnitTests.swift
@@ -334,7 +334,7 @@ internal final class ClientUnitTests: HieroUnitTestCase {
             guard let hError = error as? HError else {
                 XCTFail("Expected HError, got \(type(of: error))")
                 return
-            }
+         }
 
             XCTAssertEqual(hError.kind, .illegalState)
             XCTAssertTrue(hError.description.contains("non-negative"))


### PR DESCRIPTION
Summary

This PR implements the `defaultMaxQueryPayment` feature for the Hiero Swift SDK `Client` class, bringing it in line with other official Hiero SDK implementations (Java, Go, JavaScript, Python, and Rust).

Changes

- Added a private `_maxQueryPayment: ManagedAtomic<Int64>` property to `Client.swift`
- Implemented `getDefaultMaxQueryPayment() -> Hbar?` — returns the current default maximum query payment, or `nil` if not set
- Implemented `setDefaultMaxQueryPayment(_ payment: Hbar) throws -> Self` — sets the default maximum query payment with non-negative validation and method chaining support
- Added an internal `defaultMaxQueryPayment: Hbar?` accessor for use by `Query.swift`
- Defaults to **1 Hbar** (100,000,000 tinybars), consistent with other SDK implementations

Testing

- All existing tests pass with 0 failures
- Added unit tests covering:
  - Default value is 1 Hbar
  - Setting and getting the value works correctly
  - Negative values are rejected with an appropriate error

Notes

- Implementation follows the same atomic storage pattern as `_maxTransactionFee`
- No breaking changes to existing API or behavior
- Commits are signed with `-s -S` as required by the contribution guidelines

Closes #543
**Related issue(s)**:
